### PR TITLE
Fix clipboard paste modes

### DIFF
--- a/lib/autokey/interface.py
+++ b/lib/autokey/interface.py
@@ -581,12 +581,9 @@ class XInterfaceBase(threading.Thread):
             Gdk.threads_enter()
             text = self.clipBoard.wait_for_text()
             self.__savedClipboard = ''
-            if text is not None: self.__savedClipboard = text
-            if Gtk.get_major_version() >= 3:
-                self.clipBoard.set_text(string, -1)
-            else:
-                self.clipBoard.set_text(string)
-            # self.clipBoard.set_text(string.encode("utf-8"))
+            if text is not None:
+                self.__savedClipboard = text
+            self.clipBoard.set_text(string, -1)
             Gdk.threads_leave()
 
     def begin_send(self):


### PR DESCRIPTION
I refactored the keyboard/mouse pasting modes.
This fixes the following issues: 
- Fixes #101
- Fixes #153
It should help mitigating #151, as long as the backspace characters are not affected, because those can’t be pasted.

Note: Pasting using the mouse selection is SLOW. It takes my system about a whole second to process the events. The code waits a second before restoring the previous clipboard, but this might not be enough. It needs further investigation.
