### PR TITLE
Abstract mouse/window/keyboard interfaces 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ __pycache__
 *.egg-info
 *.pyc
 .tox/
+.eggs/
 
 # IDE's
 .idea

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,8 @@ Important misc changes
 - Various updates to the **README.rst** file to satisfy issue #681.
 - Various updates to the **README.rst** file to satisfy #pullrequestreview-1336342159.
 - Update action versions in build.yaml to latest.
+- Breaking changes to Window scripting interface to be more cross compatible.
+- Adds partially implemented 'tk' interface.
 - Update Qt/GTK "Run" button in interface to run on F5
 
 Features
@@ -25,6 +27,8 @@ Bug fixes
 - Fix crash in qt macro recording window.
 - Fix fake keyboard events not being emitted in a timely manner in some cases
 - Upgrade the **develop** branch to satisfy issue #773.
+- Splits missing program checks to display server (x11, wayland) specific
+- Update scripting/window to use iomediator instead of interface directly
 
 Version 0.96.0-beta.9
 ============================

--- a/lib/autokey/UI_common_functions.py
+++ b/lib/autokey/UI_common_functions.py
@@ -24,10 +24,13 @@ gtk_modules = ['gi', 'gi.repository.Gtk', 'gi.repository.Gdk', 'gi.repository.Pa
 qt_modules = ['PyQt5', 'PyQt5.QtGui', 'PyQt5.QtWidgets', 'PyQt5.QtCore',
             'PyQt5.Qsci']
 
-common_programs = ['wmctrl', 'ps', 'xrandr']
+# wmctrl, xrandr are x11 specific programs.
+x11_programs = ['wmctrl', 'xrandr']
+common_programs = ['ps']
 # Checking some of these appears to be redundant as some are provided by the same packages on my system but 
 # better safe than sorry.
-optional_programs = ['visgrep', 'import', 'png2pat', 'xte', 'xmousepos']
+x11_optional_programs = ['xte', 'xmousepos']
+optional_programs = ['visgrep', 'import', 'png2pat']
 gtk_programs = ['zenity']
 qt_programs = ['kdialog']
 
@@ -57,6 +60,9 @@ def checkProgramImports(programs, optional=False):
     return missing_programs
 
 def checkOptionalPrograms():
+    if common.USED_DISPLAY_SERVER == "x11":
+        checkProgramImports(x11_optional_programs, optional=True)
+
     if common.USED_UI_TYPE == "QT":
         checkProgramImports(optional_programs, optional=True)
     elif common.USED_UI_TYPE == "GTK":
@@ -74,6 +80,10 @@ def getErrorMessage(item_type, missing_items):
 
 def checkRequirements():
     errorMessage = ""
+
+    if common.USED_DISPLAY_SERVER == "x11":
+        missing_programs = checkProgramImports(x11_programs)
+
     if common.USED_UI_TYPE == "QT":
         missing_programs = checkProgramImports(common_programs+qt_programs)
         missing_modules = checkModuleImports(common_modules+qt_modules)

--- a/lib/autokey/common.py
+++ b/lib/autokey/common.py
@@ -90,3 +90,4 @@ ICON_FILE_NOTIFICATION_ERROR = "autokey-status-error"
 
 # Set at the top of each entrypoint app
 USED_UI_TYPE = "headless"
+USED_DISPLAY_SERVER = "x11"

--- a/lib/autokey/common.py
+++ b/lib/autokey/common.py
@@ -89,5 +89,10 @@ ICON_FILE_NOTIFICATION_DARK = "autokey-status-dark"
 ICON_FILE_NOTIFICATION_ERROR = "autokey-status-error"
 
 # Set at the top of each entrypoint app
+# headless, gtk or qt
 USED_UI_TYPE = "headless"
+# x11 or wayland
 USED_DISPLAY_SERVER = "x11"
+
+# "x11" or "gnomeext"
+USED_WINDOW_INTERFACE = "x11"

--- a/lib/autokey/iomediator/constants.py
+++ b/lib/autokey/iomediator/constants.py
@@ -1,1 +1,2 @@
 X_RECORD_INTERFACE = "XRecord"
+WAYLAND_INTERFACE = "Wayland"

--- a/lib/autokey/iomediator/iomediator.py
+++ b/lib/autokey/iomediator/iomediator.py
@@ -100,8 +100,16 @@ class IoMediator(threading.Thread):
 
     def grab_hotkey(self, item):
         self.interface.grab_hotkey(item)
+        
     def ungrab_hotkey(self, item):
         self.interface.ungrab_hotkey(item)
+
+    def get_window_class(self):
+        return self.interface.get_window_class()
+
+    def get_window_title(self):
+        return self.interface.get_window_title()
+
 
     # Callback methods for Interfaces ----
 

--- a/lib/autokey/iomediator/iomediator.py
+++ b/lib/autokey/iomediator/iomediator.py
@@ -21,13 +21,13 @@ import autokey
 from autokey import common
 from autokey.configmanager.configmanager import ConfigManager
 from autokey.configmanager.configmanager_constants import INTERFACE_TYPE
-from autokey.interface import XRecordInterface, AtSpiInterface
+from autokey.interface import XRecordInterface, AtSpiInterface, XWindowInterface, GnomeWindowInterface
 from autokey.sys_interface.clipboard import Clipboard
 from autokey.model.phrase import SendMode
 
 from autokey.model.key import Key, KEY_SPLIT_RE, MODIFIERS, HELD_MODIFIERS
 from autokey.model.button import Button
-from .constants import X_RECORD_INTERFACE
+from .constants import X_RECORD_INTERFACE, WAYLAND_INTERFACE
 
 CURRENT_INTERFACE = None
 
@@ -69,8 +69,16 @@ class IoMediator(threading.Thread):
         
         if self.interfaceType == X_RECORD_INTERFACE:
             self.interface = XRecordInterface(self, self.app)
+        elif self.interfaceType == WAYLAND_INTERFACE:
+            pass
+            #self.interface = GnomeExtensionInterface(self, self.app)
         else:
             self.interface = AtSpiInterface(self, self.app)
+
+        if common.USED_WINDOW_INTERFACE == "x11":
+            self.windowInterface = XWindowInterface()
+        elif common.USED_WINDOW_INTERFACE == "gnomeext":
+            self.windowInterface = GnomeWindowInterface()
 
         self.clipboard = Clipboard()
 
@@ -105,10 +113,10 @@ class IoMediator(threading.Thread):
         self.interface.ungrab_hotkey(item)
 
     def get_window_class(self):
-        return self.interface.get_window_class()
+        return self.windowInterface.get_window_class()
 
     def get_window_title(self):
-        return self.interface.get_window_title()
+        return self.windowInterface.get_window_title()
 
 
     # Callback methods for Interfaces ----

--- a/lib/autokey/scripting/__init__.py
+++ b/lib/autokey/scripting/__init__.py
@@ -30,7 +30,14 @@ from .keyboard import Keyboard
 from .mouse import Mouse
 from autokey.model.store import Store
 from .system import System
-from .window import Window
+
+
+if autokey.common.USED_WINDOW_INTERFACE == "gnomeext":
+    from .window_gnome import WindowGnome as Window
+
+elif autokey.common.USED_WINDOW_INTERFACE == "x11":
+    from .window_wmctrl import WindowWmctrl as Window
+
 
 # Platform abstraction; Allows code like `import scripting.Dialog`
 if autokey.common.USED_UI_TYPE == "QT":

--- a/lib/autokey/scripting/abstract_dialog.py
+++ b/lib/autokey/scripting/abstract_dialog.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2011 Chris Dekter
+# Copyright (C) 2023 sebastiansam55
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -12,40 +12,24 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Abstract interface for dialog interactions.
+This is an abstraction layer for platform dependent dialog handling.
+It unifies dialog handling for Qt, GTK and headless autokey UIs.
+"""
 
-"""Class for creating Qt dialogs"""
+from abc import ABC, ABCMeta, abstractmethod
+from pathlib import Path
 
-import subprocess
+logger = __import__("autokey.logger").logger.get_logger(__name__)
 
-from autokey.scripting.common import DialogData, ColourData
-
-from autokey.scripting.abstract_dialog import AbstractDialog
-
-class QtDialog(AbstractDialog):
+class AbstractDialog(ABC):
+    __metaclass__ = ABCMeta
     """
-    Provides a simple interface for the display of some basic dialogs to collect information from the user.
-
-    This version uses KDialog to integrate well with KDE. To pass additional arguments to KDialog that are
-    not specifically handled, use keyword arguments. For example, to pass the --geometry argument to KDialog
-    to specify the desired size of the dialog, pass C{geometry="700x400"} as one of the parameters. All
-    keyword arguments must be given as strings.
-
-    A note on exit codes: an exit code of 0 indicates that the user clicked OK.
+    Abstract interface for dialog interactions.
+    This is an abstraction layer for platform dependent dialog handling.
+    It unifies dialog handling for Qt, GTK and headless autokey UIs.
     """
-
-    def _run_kdialog(self, title, args, kwargs) -> DialogData:
-        for k, v in kwargs.items():
-            args.append("--" + k)
-            args.append(v)
-
-        with subprocess.Popen(
-                ["kdialog", "--title", title] + args,
-                stdout=subprocess.PIPE,
-                universal_newlines=True) as p:
-            output = p.communicate()[0][:-1]  # type: str # Drop trailing newline
-            return_code = p.returncode
-
-        return DialogData(return_code, output)
 
     def send_notification(self, title, message, icon="autokey", timeout="10", **kwargs):
         """
@@ -58,7 +42,7 @@ class QtDialog(AbstractDialog):
         @return: A tuple containing the exit code and user input
         @rtype: C{DialogData(int, str)}
         """
-        return self._run_kdialog(title, ["--title", title, "--passivepopup", message, "--icon", icon, str(timeout)], kwargs)
+        return
 
     def info_dialog(self, title="Information", message="", **kwargs):
         """
@@ -71,7 +55,7 @@ class QtDialog(AbstractDialog):
         @return: a tuple containing the exit code and user input
         @rtype: C{DialogData(int, str)}
         """
-        return self._run_kdialog(title, ["--msgbox", message], kwargs)
+        return
 
     def input_dialog(self, title="Enter a value", message="Enter a value", default="", **kwargs):
         """
@@ -85,7 +69,7 @@ class QtDialog(AbstractDialog):
         @return: a tuple containing the exit code and user input
         @rtype: C{DialogData(int, str)}
         """
-        return self._run_kdialog(title, ["--inputbox", message, default], kwargs)
+        return
 
     def password_dialog(self, title="Enter password", message="Enter password", **kwargs):
         """
@@ -98,7 +82,7 @@ class QtDialog(AbstractDialog):
         @return: a tuple containing the exit code and user input
         @rtype: C{DialogData(int, str)}
         """
-        return self._run_kdialog(title, ["--password", message], kwargs)
+        return
 
     def combo_menu(self, options, title="Choose an option", message="Choose an option", **kwargs):
         """
@@ -112,7 +96,7 @@ class QtDialog(AbstractDialog):
         @return: a tuple containing the exit code and user choice
         @rtype: C{DialogData(int, str)}
         """
-        return self._run_kdialog(title, ["--combobox", message] + options, kwargs)
+        return
 
     def list_menu(self, options, title="Choose a value", message="Choose a value", default=None, **kwargs):
         """
@@ -127,22 +111,7 @@ class QtDialog(AbstractDialog):
         @return: a tuple containing the exit code and user choice
         @rtype: C{DialogData(int, str)}
         """
-
-        choices = []
-        optionNum = 0
-        for option in options:
-            choices.append(str(optionNum))
-            choices.append(option)
-            if option == default:
-                choices.append("on")
-            else:
-                choices.append("off")
-            optionNum += 1
-
-        return_code, result = self._run_kdialog(title, ["--radiolist", message] + choices, kwargs)
-        choice = options[int(result)]
-
-        return DialogData(return_code, choice)
+        return
 
     def list_menu_multi(self, options, title="Choose one or more values", message="Choose one or more values",
                         defaults: list=None, **kwargs):
@@ -158,26 +127,7 @@ class QtDialog(AbstractDialog):
         @return: a tuple containing the exit code and user choice
         @rtype: C{DialogData(int, List[str])}
         """
-
-        if defaults is None:
-            defaults = []
-        choices = []
-        optionNum = 0
-        for option in options:
-            choices.append(str(optionNum))
-            choices.append(option)
-            if option in defaults:
-                choices.append("on")
-            else:
-                choices.append("off")
-            optionNum += 1
-
-        return_code, output = self._run_kdialog(title, ["--separate-output", "--checklist", message] + choices, kwargs)
-        results = output.split()
-
-        choices = [options[int(choice_index)] for choice_index in results]
-
-        return DialogData(return_code, choices)
+        return
 
     def open_file(self, title="Open File", initialDir="~", fileTypes="*|All Files", rememberAs=None, **kwargs):
         """
@@ -192,11 +142,8 @@ class QtDialog(AbstractDialog):
         @return: a tuple containing the exit code and file path
         @rtype: C{DialogData(int, str)}
         """
-        if rememberAs is not None:
-            return self._run_kdialog(title, ["--getopenfilename", initialDir, fileTypes, ":" + rememberAs], kwargs)
-        else:
-            return self._run_kdialog(title, ["--getopenfilename", initialDir, fileTypes], kwargs)
-
+        return
+    
     def save_file(self, title="Save As", initialDir="~", fileTypes="*|All Files", rememberAs=None, **kwargs):
         """
         Show a Save As dialog
@@ -210,10 +157,8 @@ class QtDialog(AbstractDialog):
         @return: a tuple containing the exit code and file path
         @rtype: C{DialogData(int, str)}
         """
-        if rememberAs is not None:
-            return self._run_kdialog(title, ["--getsavefilename", initialDir, fileTypes, ":" + rememberAs], kwargs)
-        else:
-            return self._run_kdialog(title, ["--getsavefilename", initialDir, fileTypes], kwargs)
+        return
+
 
     def choose_directory(self, title="Select Directory", initialDir="~", rememberAs=None, **kwargs):
         """
@@ -227,10 +172,7 @@ class QtDialog(AbstractDialog):
         @return: a tuple containing the exit code and chosen path
         @rtype: C{DialogData(int, str)}
         """
-        if rememberAs is not None:
-            return self._run_kdialog(title, ["--getexistingdirectory", initialDir, ":" + rememberAs], kwargs)
-        else:
-            return self._run_kdialog(title, ["--getexistingdirectory", initialDir], kwargs)
+        return
 
     def choose_colour(self, title="Select Colour", **kwargs):
         """
@@ -242,11 +184,7 @@ class QtDialog(AbstractDialog):
         @return: a tuple containing the exit code and colour
         @rtype: C{DialogData(int, str)}
         """
-        return_data = self._run_kdialog(title, ["--getcolor"], kwargs)
-        if return_data.successful:
-            return DialogData(return_data.return_code, ColourData.from_html(return_data.data))
-        else:
-            return DialogData(return_data.return_code, None)
+        return
 
     def calendar(self, title="Choose a date", format_str="%Y-%m-%d", date="today", **kwargs):
         """
@@ -262,4 +200,4 @@ class QtDialog(AbstractDialog):
         @return: a tuple containing the exit code and date
         @rtype: C{DialogData(int, str)}
         """
-        return self._run_kdialog(title, ["--calendar", title], kwargs)
+        return

--- a/lib/autokey/scripting/abstract_window.py
+++ b/lib/autokey/scripting/abstract_window.py
@@ -1,0 +1,283 @@
+# Copyright (C) 2011 Chris Dekter
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+Abstract interface for window interactions.
+This is an abstraction layer for platform dependent window handling.
+"""
+
+from abc import ABC, ABCMeta, abstractmethod
+
+
+
+
+class AbstractWindow(ABC):
+    __metaclass__ = ABCMeta
+    """
+    Basic window management
+    """
+
+    @abstractmethod
+    def wait_for_focus(self, title, timeOut=5):
+        """
+        Wait for window with the given title to have focus
+
+        Usage: C{window.wait_for_focus(title, timeOut=5)}
+
+        If the window becomes active, returns True. Otherwise, returns False if
+        the window has not become active by the time the timeout has elapsed.
+
+        @param title: title to match against (as a regular expression)
+        @param timeOut: period (seconds) to wait before giving up
+        @rtype: boolean
+        """
+        return
+
+    @abstractmethod
+    def wait_for_exist(self, title, timeOut=5, by_hex=False):
+        """
+        Wait for window with the given title to be created
+
+        Usage: C{window.wait_for_exist(title, timeOut=5)}
+
+        If the window is in existence, returns True. Otherwise, returns False if
+        the window has not been created by the time the timeout has elapsed.
+
+        @param title: title to match against (as a regular expression)
+        @param timeOut: period (seconds) to wait before giving up
+        @param by_hex: If true, C{wmctrl} will interpret the C{title} as a hexid
+        @rtype: boolean
+        """
+        return
+
+    @abstractmethod
+    def activate(self, title, switchDesktop=False, matchClass=False, by_hex=False):
+        """
+        Activate the specified window, giving it input focus
+
+        Usage: C{window.activate(title, switchDesktop=False, matchClass=False)}
+
+        If switchDesktop is False (default), the window will be moved to the current desktop
+        and activated. Otherwise, switch to the window's current desktop and activate it there.
+
+        @param title: window title to match against (as case-insensitive substring match)
+        @param switchDesktop: whether or not to switch to the window's current desktop
+        @param matchClass: if True, match on the window class instead of the title
+        @param by_hex: If true, C{wmctrl} will interpret the C{title} as a hexid
+        """
+        return
+
+    @abstractmethod
+    def close(self, title, matchClass=False, by_hex=False):
+        """
+        Close the specified window gracefully
+
+        Usage: C{window.close(title, matchClass=False)}
+
+        @param title: window title to match against (as case-insensitive substring match)
+        @param matchClass: if True, match on the window class instead of the title
+        @param by_hex: If true, C{wmctrl} will interpret the C{title} as a hexid
+        """
+        return
+
+    @abstractmethod
+    def resize(self, title, width=-1, height=-1, matchClass=False, by_hex=False):
+        """
+        Resize the specified window
+
+        Usage: C{window.resize(title, xOrigin=-1, yOrigin=-1, width=-1, height=-1, matchClass=False)}
+
+        Leaving and of the position/dimension values as the default (-1) will cause that
+        value to be left unmodified.
+
+        @param title: window title to match against (as case-insensitive substring match)
+        @param xOrigin: new x origin of the window (upper left corner)
+        @param yOrigin: new y origin of the window (upper left corner)
+        @param width: new width of the window
+        @param height: new height of the window
+        @param matchClass: if C{True}, match on the window class instead of the title
+        @param by_hex: If true, C{wmctrl} will interpret the C{title} as a hexid
+        """
+        return
+    
+    @abstractmethod
+    def move(self, title, x, y, by_id=False):
+        """
+        Move the specified window
+
+        Usage: C{window.move(title, x, y, by_id=False)}
+
+        @param title: window title to match against.
+        @param x: new x origin of the window (upper left corner)
+        @param y: new y origin of the window (upper left corner)
+        @param by_id: If true, C{wmctrl} will interpret the C{title} as a hexid
+
+        """
+        return
+
+    @abstractmethod
+    def move_to_desktop(self, title, deskNum, matchClass=False, by_hex=False):
+        """
+        Move the specified window to the given desktop
+
+        Usage: C{window.move_to_desktop(title, deskNum, matchClass=False)}
+
+        @param title: window title to match against (as case-insensitive substring match)
+        @param deskNum: desktop to move the window to (note: zero based)
+        @param matchClass: if True, match on the window class instead of the title
+        @param by_hex: If true, C{wmctrl} will interpret the C{title} as a hexid
+        """
+        return
+
+    @abstractmethod
+    def switch_desktop(self, deskNum):
+        """
+        Switch to the specified desktop
+
+        Usage: C{window.switch_desktop(deskNum)}
+
+        @param deskNum: desktop to switch to (note: zero based)
+        """
+        return
+
+    @abstractmethod
+    def set_property(self, title, action, prop, matchClass=False, by_hex=False):
+        """
+        Set a property on the given window using the specified action
+
+        Usage: C{window.set_property(title, action, prop, matchClass=False)}
+
+        Allowable actions: C{add, remove, toggle}
+        Allowable properties: C{modal, sticky, maximized_vert, maximized_horz, shaded, skip_taskbar,
+        skip_pager, hidden, fullscreen, above}
+
+        @param title: window title to match against (as case-insensitive substring match)
+        @param action: one of the actions listed above
+        @param prop: one of the properties listed above
+        @param matchClass: if True, match on the window class instead of the title
+        @param by_hex: If true, C{wmctrl} will interpret the C{title} as a hexid
+        """
+        return
+
+    @abstractmethod
+    def get_active_geometry(self):
+        """
+        Get the geometry of the currently active window. Uses the C{:ACTIVE:} function of C{wmctrl}.
+
+        Usage: C{window.get_active_geometry()}
+
+        @return: a 4-tuple containing the x-origin, y-origin, width and height of the window (in pixels)
+        @rtype: C{tuple(int, int, int, int)}
+        """
+        return
+
+    @abstractmethod
+    def get_active_title(self):
+        """
+        Get the visible title of the currently active window
+
+        Usage: C{window.get_active_title()}
+
+        @return: the visible title of the currently active window
+        @rtype: C{str}
+        """
+        return
+
+    @abstractmethod
+    def get_active_class(self):
+        """
+        Get the class of the currently active window
+
+        Usage: C{window.get_active_class()}
+
+        @return: the class of the currentle active window
+        @rtype: C{str}
+        """
+        return
+    
+    @abstractmethod
+    def get_active_info(self):
+        """
+        Get all info about the currently active window
+
+        Usage: C{window.get_active_info()}
+
+        @return: a dictionary containing all info about the currently active window
+        @rtype: C{dict}
+        """
+        return
+    
+
+    @abstractmethod
+    def center_window(self, title=":ACTIVE:", win_width=None, win_height=None, monitor=0, matchClass=False, by_hex=False):
+        """
+        Centers the active (or window selected by title) window. Requires xrandr for getting monitor sizes and offsets.
+
+        @param title: Title of the window to center (defaults to using the active window)
+        @param win_width: Width of the centered window, defaults to screenx/3. Use -1 to center without size change.
+        @param win_height: Height of the centered window, defaults to screeny/3. Use -1 to center without size change.
+        @param monitor: Monitor number (0 is primary, listed via C{xrandr --listactivemonitors} etc.)
+        @param matchClass: if True, match on the window class instead of the title
+        @raises ValueError: If title or desktop is not found by wmctrl
+        @param by_hex: If true, C{wmctrl} will interpret the C{title} as a hexid
+        """
+        return
+
+    @abstractmethod
+    def get_window_list(self, filter_desktop=-1):
+        """
+        Returns a list of windows matching an optional desktop filter, requires C{wmctrl}!
+
+        Each list item consists of: C{[hexid, desktop, hostname, title]}
+
+        Where the C{hexid} is the ID used for some other functions (like L{import -window} from ImageMagick).
+
+        C{desktop} is the number of which desktop (sometimes called workspaces) the window appears upon.
+
+        C{hostname} is the hostname of your computer.
+
+        C{title} is the title that you would usually see in your window manager of choice.
+
+        @param filter_desktop: String, (usually 0-n) to filter the windows by. Any window not on the given desktop will not be returned.
+        @return: C{[[hexid1, desktop1, hostname1, title1], [hexid2,desktop2,hostname2,title2], ...etc]}
+        Returns C{[]} if no windows are found.
+        """
+        return
+
+    @abstractmethod
+    def get_window_hex(self, title):
+        """
+        Returns the hexid of the first window to match title.
+
+        @param title: Window title to match for returning hexid
+        @return: Returns hexid of the window to be used for other functions See L{get_window_geom}, L{visgrep_by_window_id}
+
+        Returns C{None} if no matches are found
+        """
+        return
+
+
+
+    @abstractmethod
+    def get_window_geometry(self, title, by_hex=False):
+        """
+        Uses C{wmctrl} to return the window geometry of the given window title. Returns where the location of the
+        top left hand corner of the window is and the width/height of the window.
+
+
+        @param title
+        @return: C{[offsetx, offsety, sizex, sizey]} Returns none if no matches are found
+        """
+        return

--- a/lib/autokey/scripting/dialog_gtk.py
+++ b/lib/autokey/scripting/dialog_gtk.py
@@ -20,8 +20,10 @@ import subprocess
 
 from autokey.scripting.common import DialogData, ColourData
 
+from autokey.scripting.abstract_dialog import AbstractDialog
 
-class GtkDialog:
+
+class GtkDialog(AbstractDialog):
     """
     Provides a simple interface for the display of some basic dialogs to collect information from the user.
 

--- a/lib/autokey/scripting/highlevel.py
+++ b/lib/autokey/scripting/highlevel.py
@@ -14,13 +14,7 @@ class PatternNotFound(Exception):
     """Exception raised by functions"""
     pass
 
-# numeric representation of the mouse buttons. For use in visgrep.
-LEFT = 1
-"""Left mouse button"""
-MIDDLE = 2
-"""Middle mouse button"""
-RIGHT = 3
-"""Right mouse button"""
+from autokey.model import Button
 
 
 def visgrep(scr: str, pat: str, tolerance: int = 0) -> int:
@@ -163,7 +157,7 @@ def acknowledge_gnome_notification():
     mouse_move(10000, 10000)  # TODO: What if the screen is larger? Loop until mouse position does not change anymore?
     x, y = mouse_pos()
     mouse_rmove(-x/2, 0)
-    mouse_click(LEFT)
+    mouse_click(Button.LEFT)
     time.sleep(.2)
     mouse_move(x0, y0)
 

--- a/lib/autokey/scripting/highlevel.py
+++ b/lib/autokey/scripting/highlevel.py
@@ -14,7 +14,7 @@ class PatternNotFound(Exception):
     """Exception raised by functions"""
     pass
 
-from autokey.model import Button
+from autokey.model.button import Button
 
 
 def visgrep(scr: str, pat: str, tolerance: int = 0) -> int:

--- a/lib/autokey/scripting/window.py
+++ b/lib/autokey/scripting/window.py
@@ -60,7 +60,7 @@ class Window:
         regex = re.compile(title)
         waited = 0
         while waited <= timeOut:
-            if regex.match(self.mediator.interface.get_window_title()):
+            if regex.match(self.mediator.get_window_title()):
                 return True
 
             if timeOut == 0:
@@ -240,10 +240,10 @@ class Window:
 
         Usage: C{window.get_active_title()}
 
-        @return: the visible title of the currentle active window
+        @return: the visible title of the currently active window
         @rtype: C{str}
         """
-        return self.mediator.interface.get_window_title()
+        return self.mediator.get_window_title()
 
     def get_active_class(self):
         """
@@ -254,7 +254,7 @@ class Window:
         @return: the class of the currentle active window
         @rtype: C{str}
         """
-        return self.mediator.interface.get_window_class()
+        return self.mediator.get_window_class()
 
     def center_window(self, title=":ACTIVE:", win_width=None, win_height=None, monitor=0, matchClass=False, by_hex=False):
         """

--- a/lib/autokey/scripting/window_gnome.py
+++ b/lib/autokey/scripting/window_gnome.py
@@ -1,0 +1,352 @@
+# Copyright (C) 2011 Chris Dekter
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+Abstract interface for window interactions.
+This is an abstraction layer for platform dependent window handling.
+"""
+
+from autokey.scripting.abstract_window import AbstractWindow
+
+import time
+import re
+
+
+class WindowGnome(AbstractWindow):
+    """
+    Basic window management using a GNOME extension via dbus
+
+    Initial implementation using:
+    https://github.com/sebastiansam55/autokey-gnome-extension
+
+    Have to look into publication of the extension as well.
+    """
+
+    def __init__(self, mediator):
+        self.mediator = mediator
+        self.windowInterface = self.mediator.windowInterface
+
+        #TODO if the gnome shell crashes these need to be reinitialized, not sure how to handle that scenario
+
+        
+
+    def wait_for_focus(self, title, timeOut=5):
+        """
+        Wait for window with the given title to have focus
+
+        Usage: C{window.wait_for_focus(title, timeOut=5)}
+
+        If the window becomes active, returns True. Otherwise, returns False if
+        the window has not become active by the time the timeout has elapsed.
+
+        @param title: title to match against (as a regular expression)
+        @param timeOut: period (seconds) to wait before giving up
+        @rtype: boolean
+        """
+        regex = re.compile(title)
+        waited = 0
+
+        while waited < timeOut:
+            if regex.match(self.get_active_title()):
+                return True 
+            if timeOut == 0:
+                break
+
+            time.sleep(0.3)
+            waited += 0.3
+        return
+
+    def wait_for_exist(self, title, timeOut=5, by_id=False):
+        """
+        Wait for window with the given title to be created
+
+        Usage: C{window.wait_for_exist(title, timeOut=5)}
+
+        If the window is in existence, returns True. Otherwise, returns False if
+        the window has not been created by the time the timeout has elapsed.
+
+        @param title: title to match against (as a regular expression)
+        @param timeOut: period (seconds) to wait before giving up
+        @param by_id: If true, C{wmctrl} will interpret the C{title} as a id
+        @rtype: boolean
+        """
+        waited = 0
+        while waited < timeOut:
+            windowList = self.get_window_list()
+            for window in windowList:
+                if by_id:
+                    if title == window["id"]:
+                        return True
+                else:
+                    if title in window["wm_title"]:
+                        return True
+                if timeOut == 0:
+                    break
+            time.sleep(0.3)
+            waited += 0.3
+        
+        return False
+
+    def activate(self, title, switchDesktop=False, matchClass=False, by_id=False):
+        """
+        Activate the specified window, giving it input focus
+
+        Usage: C{window.activate(title, switchDesktop=False, matchClass=False)}
+
+        If switchDesktop is False (default), the window will be moved to the current desktop
+        and activated. Otherwise, switch to the window's current desktop and activate it there.
+
+        @param title: window title to match against (as case-insensitive substring match)
+        @param switchDesktop: whether or not to switch to the window's current desktop
+        @param matchClass: if True, match on the window class instead of the title
+        @param by_id: If true, C{wmctrl} will interpret the C{title} as a id
+        """
+        #TODO: implement switchDesktop, matchClass
+        if by_id:
+            self.windowInterface._dbus_activate_window(title)
+        else:
+            id = self.get_window_id(title)
+            self.windowInterface._dbus_activate_window(id)
+
+
+    def close(self, title, by_id=False):
+        """
+        Close the specified window gracefully
+
+        Usage: C{window.close(title, matchClass=False)}
+
+        @param title: window title to match against (as case-insensitive substring match)
+        @param by_id: If true it will interpret the C{title} as an id
+        """
+        if by_id:
+            self.windowInterface._dbus_close_window(title)
+        else:
+            id = self.get_window_id(title)
+            self.windowInterface._dbus_close_window(id)
+
+    def resize(self, title, width=-1, height=-1, by_id=False):
+        """
+        Resize the specified window, note that this appears to not include the window border/title bar.
+
+        Usage: C{window.resize(title, width=-1, height=-1)}
+
+
+        @param title: window title to match against (as case-insensitive substring match)
+        @param width: new width of the window
+        @param height: new height of the window
+        @param by_id: If true, it will interpret the C{title} as an id
+        """
+        if by_id:
+            self.windowInterface._dbus_resize_window(title, width, height)
+        else:
+            id = self.get_window_id(title)
+            self.windowInterface._dbus_resize_window(id, width, height)
+
+
+    def move(self, title, x=-1, y=-1, by_id=False):
+        """
+        Move the specified window
+
+        Usage: C{window.move(title, x=-1, y=-1)}
+
+        @param title: window title to match against (as case-insensitive substring match)
+        @param x: new x position of the window
+        @param y: new y position of the window
+        @param by_id: If true, it will interpret the C{title} as an id
+        """
+        if by_id:
+            self.windowInterface._dbus_move_window(title, x, y)
+        else:
+            id = self.get_window_id(title)
+            self.windowInterface._dbus_move_window(id, x, y)
+
+    def move_to_desktop(self, title, deskNum, matchClass=False, by_id=False):
+        """
+        Move the specified window to the given desktop
+
+        Usage: C{window.move_to_desktop(title, deskNum, matchClass=False)}
+
+        @param title: window title to match against (as case-insensitive substring match)
+        @param deskNum: desktop to move the window to (note: zero based)
+        @param matchClass: if True, match on the window class instead of the title
+        @param by_id: If true, C{wmctrl} will interpret the C{title} as a id
+        """
+        #TODO: is this possible to implement with the gnome extension?
+        raise NotImplementedError
+
+    def switch_desktop(self, deskNum):
+        """
+        Switch to the specified desktop
+
+        Usage: C{window.switch_desktop(deskNum)}
+
+        @param deskNum: desktop to switch to (note: zero based)
+        """
+        #TODO: is this possible to implement with the gnome extension?
+        raise NotImplementedError
+
+    def set_property(self, title, action, prop, matchClass=False, by_id=False):
+        """
+        Set a property on the given window using the specified action
+
+        Usage: C{window.set_property(title, action, prop, matchClass=False)}
+
+        Allowable actions: C{add, remove, toggle}
+        Allowable properties: C{modal, sticky, maximized_vert, maximized_horz, shaded, skip_taskbar,
+        skip_pager, hidden, fullscreen, above}
+
+        @param title: window title to match against (as case-insensitive substring match)
+        @param action: one of the actions listed above
+        @param prop: one of the properties listed above
+        @param matchClass: if True, match on the window class instead of the title
+        @param by_id: If true, C{wmctrl} will interpret the C{title} as a id
+        """
+        #TODO: is this possible to implement with the gnome extension?
+        raise NotImplementedError
+    
+    def get_active_info(self):
+        """
+        Get all info about the currently active window
+
+        Usage: C{window.get_active_info()}
+
+        @return: a dictionary containing all info about the currently active window
+        @rtype: C{dict}
+        """
+        window_list = self.windowInterface._dbus_window_list()
+        for window in window_list:
+            if window['focus']:
+                return window
+
+    def get_active_geometry(self):
+        """
+        Get the geometry of the currently active window. Uses the C{:ACTIVE:} function of C{wmctrl}.
+
+        Usage: C{window.get_active_geometry()}
+
+        @return: a 4-tuple containing the x-origin, y-origin, width and height of the window (in pixels)
+        @rtype: C{tuple(int, int, int, int)}
+        """
+        active_info = self.get_active_info()
+        x = active_info['x']
+        y = active_info['y']
+        width = active_info['width']
+        height = active_info['height']
+        return [x, y, width, height]
+
+    def get_active_title(self):
+        """
+        Get the visible title of the currently active window
+
+        Usage: C{window.get_active_title()}
+
+        @return: the visible title of the currently active window
+        @rtype: C{str}
+        """
+        return self.get_active_info()['wm_title']
+
+    def get_active_class(self):
+        """
+        Get the class of the currently active window
+
+        Usage: C{window.get_active_class()}
+
+        @return: the class of the currently active window
+        @rtype: C{str}
+        """
+        return self.get_active_info()['wm_class']
+
+    def center_window(self, title=":ACTIVE:", win_width=None, win_height=None, monitor=0, matchClass=False, by_id=False):
+        """
+        Centers the active (or window selected by title) window. Requires xrandr for getting monitor sizes and offsets.
+
+        @param title: Title of the window to center (defaults to using the active window)
+        @param win_width: Width of the centered window, defaults to screenx/3. Use -1 to center without size change.
+        @param win_height: Height of the centered window, defaults to screeny/3. Use -1 to center without size change.
+        @param monitor: Monitor number (0 is primary, listed via C{xrandr --listactivemonitors} etc.)
+        @param matchClass: if True, match on the window class instead of the title
+        @raises ValueError: If title or desktop is not found by wmctrl
+        @param by_id: If true, C{wmctrl} will interpret the C{title} as a id
+        """
+        raise NotImplementedError
+
+    def get_window_list(self, filter_desktop=-1):
+        """
+        Returns a list of windows matching an optional desktop filter, requires C{wmctrl}!
+
+        Each list item consists of: C{[id, title, class]}
+
+        Where the C{id} is the ID used for some other functions.
+
+        C{title} is the title that you would usually see in your window manager of choice.
+
+        C{class} is the class of the window, usually the name of the application, like C{firefox}.
+
+        @param filter_desktop: String, (usually 0-n) to filter the windows by. Any window not on the given desktop will not be returned.
+        @return: C{[[id1, title1, class1], [id2, title2, class2], ...etc]}
+        Returns C{[]} if no windows are found.
+        """
+        window_list = []
+        dbus_window_list = self.windowInterface._dbus_window_list()
+        for window in dbus_window_list:
+            window_list.append([window['id'],  window['wm_title'], window['wm_class']])
+        
+        return window_list
+
+    def get_window_hex(self, title):
+        """
+        Returns the id of the first window to match title.
+
+        @param title: Window title to match for returning id
+        @return: Returns id of the window to be used for other functions See L{get_window_geom}, L{visgrep_by_window_id}
+
+        Returns C{None} if no matches are found
+        """
+        raise NotImplementedError
+
+
+    def get_window_id(self, title):
+        """
+        Returns the id of the first window to match title.
+
+        @param title: Window title to match for returning id
+        @return: Returns id of the window to be used for other functions.
+
+        Returns C{None} if no matches are found
+        """
+        window_list = self.windowInterface._dbus_window_list()
+        for window in window_list:
+            if window['wm_title'] == title:
+                return window['id']
+        return None
+
+
+    def get_window_geometry(self, title):
+        """
+        Returns where the location of the top left hand corner of the window is and the width/height of the window.
+
+        @param title
+        @return: C{[x, y, width, height]} Returns C{None} if no matches are found
+        """
+        window_list = self.windowInterface_dbus_window_list()
+        for window in window_list:
+            if window['wm_title'] == title:
+                x = window['x']
+                y = window['y']
+                width = window['width']
+                height = window['height']
+                return [x, y, width, height]
+        return None
+

--- a/lib/autokey/scripting/window_wmctrl.py
+++ b/lib/autokey/scripting/window_wmctrl.py
@@ -1,0 +1,411 @@
+# Copyright (C) 2011 Chris Dekter
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Basic window management. Requies C{wmctrl} and C{xrandr} to be installed."""
+
+import re
+import subprocess
+import time
+
+from autokey.scripting.abstract_window import AbstractWindow
+
+# this regex extracts the pertinant data from wmctrl output, see test_window.py for more info
+WMCTRL_GEOM_REGEX = r"^(0x[0-9a-fA-F]{8})\s{1,}(\d*)\s{1,}(\d*)\s{1,}(\d{1,})\s{1,}(\d{1,})\s{1,}(\d{1,})\s{1,}(.*?)\s{1,}(.*?)$"
+XRANDR_MONITOR_REGEX = r" (\d{3,4}).*?x(\d{3,4})\/.*?\+(\d{1,4})\+(\d{1,4})"
+#Example Output:
+#Monitors: 2
+# 0: +*HDMI-0 1920/521x1080/293+0+0  HDMI-0
+# 1: +DVI-D-0 1440/408x900/255+1920+0  DVI-D-0
+# Regex gets  ____ and ____    ____ _
+# this translates to monitor x and y size, and x and y offset for each monitor
+
+class WindowWmctrl(AbstractWindow):
+    """
+    Basic window management using wmctrl
+
+    Note: in all cases where a window title is required (with the exception of wait_for_focus()),
+    two special values of window title are permitted:
+
+    :ACTIVE: - select the currently active window
+    :SELECT: - select the desired window by clicking on it
+    """
+
+    def __init__(self, mediator):
+        self.mediator = mediator
+
+    def wait_for_focus(self, title, timeOut=5):
+        """
+        Wait for window with the given title to have focus
+
+        Usage: C{window.wait_for_focus(title, timeOut=5)}
+
+        If the window becomes active, returns True. Otherwise, returns False if
+        the window has not become active by the time the timeout has elapsed.
+
+        @param title: title to match against (as a regular expression)
+        @param timeOut: period (seconds) to wait before giving up
+        @rtype: boolean
+        """
+        regex = re.compile(title)
+        waited = 0
+        while waited <= timeOut:
+            if regex.match(self.mediator.get_window_title()):
+                return True
+
+            if timeOut == 0:
+                break  # zero length timeout, if not matched go straight to end
+
+            time.sleep(0.3)
+            waited += 0.3
+
+        return False
+
+    def wait_for_exist(self, title, timeOut=5, by_hex=False):
+        """
+        Wait for window with the given title to be created
+
+        Usage: C{window.wait_for_exist(title, timeOut=5)}
+
+        If the window is in existence, returns True. Otherwise, returns False if
+        the window has not been created by the time the timeout has elapsed.
+
+        @param title: title to match against (as a regular expression)
+        @param timeOut: period (seconds) to wait before giving up
+        @param by_hex: If true, C{wmctrl} will interpret the C{title} as a hexid
+        @rtype: boolean
+        """
+        waited = 0
+        while waited <= timeOut:
+            windowList = self.get_window_list()
+            for window in windowList:
+                if by_hex:
+                    if title == window[0]: return True
+                else:
+                    if title == window[3]: return True
+
+            if timeOut == 0:
+                break  # zero length timeout, if not matched go straight to end
+
+            time.sleep(0.3)
+            waited += 0.3
+
+        return False
+
+    def activate(self, title, switchDesktop=False, matchClass=False, by_hex=False):
+        """
+        Activate the specified window, giving it input focus
+
+        Usage: C{window.activate(title, switchDesktop=False, matchClass=False)}
+
+        If switchDesktop is False (default), the window will be moved to the current desktop
+        and activated. Otherwise, switch to the window's current desktop and activate it there.
+
+        @param title: window title to match against (as case-insensitive substring match)
+        @param switchDesktop: whether or not to switch to the window's current desktop
+        @param matchClass: if True, match on the window class instead of the title
+        @param by_hex: If true, C{wmctrl} will interpret the C{title} as a hexid
+        """
+        if switchDesktop:
+            xArgs = ["-a", title]
+        else:
+            xArgs = ["-R", title]
+
+        if by_hex:
+            xArgs += ["-i"] # use hex id instead of window title
+
+        if matchClass:
+            xArgs += ["-x"]
+        self._run_wmctrl(xArgs)
+
+    def close(self, title, matchClass=False, by_hex=False):
+        """
+        Close the specified window gracefully
+
+        Usage: C{window.close(title, matchClass=False)}
+
+        @param title: window title to match against (as case-insensitive substring match)
+        @param matchClass: if True, match on the window class instead of the title
+        @param by_hex: If true, C{wmctrl} will interpret the C{title} as a hexid
+        """
+        xArgs = ["-c", title]
+        if matchClass:
+            xArgs += ["-x"]
+        if by_hex:
+            xArgs += ["-i"]
+
+        self._run_wmctrl(xArgs)
+
+    def resize(self, title, xOrigin=-1, yOrigin=-1, width=-1, height=-1, matchClass=False, by_hex=False):
+        """
+        Resize and/or move the specified window
+
+        Usage: C{window.resize_move(title, xOrigin=-1, yOrigin=-1, width=-1, height=-1, matchClass=False)}
+
+        Leaving and of the position/dimension values as the default (-1) will cause that
+        value to be left unmodified.
+
+        @param title: window title to match against (as case-insensitive substring match)
+        @param xOrigin: new x origin of the window (upper left corner)
+        @param yOrigin: new y origin of the window (upper left corner)
+        @param width: new width of the window
+        @param height: new height of the window
+        @param matchClass: if C{True}, match on the window class instead of the title
+        @param by_hex: If true, C{wmctrl} will interpret the C{title} as a hexid
+        """
+        mvArgs = ["0", str(xOrigin), str(yOrigin), str(width), str(height)]
+        xArgs = []
+        if matchClass:
+            xArgs += ["-x"]
+        if by_hex:
+            xArgs += ["-i"]
+        self._run_wmctrl(["-r", title, "-e", ','.join(mvArgs)] + xArgs)
+
+    def move(self, title, x, y):
+        """
+        Move the specified window
+
+        """
+        raise NotImplementedError("move() is not implemented yet")
+
+    def move_to_desktop(self, title, deskNum, matchClass=False, by_hex=False):
+        """
+        Move the specified window to the given desktop
+
+        Usage: C{window.move_to_desktop(title, deskNum, matchClass=False)}
+
+        @param title: window title to match against (as case-insensitive substring match)
+        @param deskNum: desktop to move the window to (note: zero based)
+        @param matchClass: if True, match on the window class instead of the title
+        @param by_hex: If true, C{wmctrl} will interpret the C{title} as a hexid
+        """
+        xArgs = []
+        if matchClass:
+            xArgs += ["-x"]
+        if by_hex:
+            xArgs += ["-i"]
+        self._run_wmctrl(["-r", title, "-t", str(deskNum)] + xArgs)
+
+    def switch_desktop(self, deskNum):
+        """
+        Switch to the specified desktop
+
+        Usage: C{window.switch_desktop(deskNum)}
+
+        @param deskNum: desktop to switch to (note: zero based)
+        """
+        self._run_wmctrl(["-s", str(deskNum)])
+
+    def set_property(self, title, action, prop, matchClass=False, by_hex=False):
+        """
+        Set a property on the given window using the specified action
+
+        Usage: C{window.set_property(title, action, prop, matchClass=False)}
+
+        Allowable actions: C{add, remove, toggle}
+        Allowable properties: C{modal, sticky, maximized_vert, maximized_horz, shaded, skip_taskbar,
+        skip_pager, hidden, fullscreen, above}
+
+        @param title: window title to match against (as case-insensitive substring match)
+        @param action: one of the actions listed above
+        @param prop: one of the properties listed above
+        @param matchClass: if True, match on the window class instead of the title
+        @param by_hex: If true, C{wmctrl} will interpret the C{title} as a hexid
+        """
+        xArgs = []
+        if matchClass:
+            xArgs += ["-x"]
+        if by_hex:
+            xArgs += ["-i"]
+        self._run_wmctrl(["-r", title, "-b" + action + ',' + prop] + xArgs)
+
+    def get_active_geometry(self):
+        """
+        Get the geometry of the currently active window. Uses the C{:ACTIVE:} function of C{wmctrl}.
+
+        Usage: C{window.get_active_geometry()}
+
+        @return: a 4-tuple containing the x-origin, y-origin, width and height of the window (in pixels)
+        @rtype: C{tuple(int, int, int, int)}
+        """
+        #wrapper for get_window_geometry()
+        return self.get_window_geometry(":ACTIVE:")
+
+    def get_active_title(self):
+        """
+        Get the visible title of the currently active window
+
+        Usage: C{window.get_active_title()}
+
+        @return: the visible title of the currently active window
+        @rtype: C{str}
+        """
+        return self.mediator.get_window_title()
+
+    def get_active_class(self):
+        """
+        Get the class of the currently active window
+
+        Usage: C{window.get_active_class()}
+
+        @return: the class of the currentle active window
+        @rtype: C{str}
+        """
+        return self.mediator.get_window_class()
+
+
+    def get_active_info(self):
+        """
+        Get all info about the currently active window
+
+        Usage: C{window.get_active_info()}
+
+        @return: a dictionary containing all info about the currently active window
+        @rtype: C{dict}
+        """
+        raise NotImplementedError
+
+    def center_window(self, title=":ACTIVE:", win_width=None, win_height=None, monitor=0, matchClass=False, by_hex=False):
+        """
+        Centers the active (or window selected by title) window. Requires xrandr for getting monitor sizes and offsets.
+
+        @param title: Title of the window to center (defaults to using the active window)
+        @param win_width: Width of the centered window, defaults to screenx/3. Use -1 to center without size change.
+        @param win_height: Height of the centered window, defaults to screeny/3. Use -1 to center without size change.
+        @param monitor: Monitor number (0 is primary, listed via C{xrandr --listactivemonitors} etc.)
+        @param matchClass: if True, match on the window class instead of the title
+        @raises ValueError: If title or desktop is not found by wmctrl
+        @param by_hex: If true, C{wmctrl} will interpret the C{title} as a hexid
+        """
+        #could also use Gdk.Display.get_default().get_montiors etc.
+        #Used xrandr for ease of cross Gtk/Qt use, wayland might require an alternate implementation
+        returncode, output = self._run_xrandr(["--listactivemonitors"])
+        matches = re.findall(XRANDR_MONITOR_REGEX, output, re.MULTILINE)
+
+        width = int(matches[monitor][0])
+        height = int(matches[monitor][1])
+        x_offset = int(matches[monitor][2])
+        y_offset = int(matches[monitor][3])
+
+        #work backwards from the size of the window
+        if win_width is None:
+            win_width = round(width/2)
+        if win_height is None:
+            win_height = round(height/2)
+        top_x = round((width-win_width)/2)
+        top_y = round((height-win_height)/2)
+
+        #remove maximized attributes from window
+        self.set_property(title, "remove", "maximized_vert", matchClass=matchClass, by_hex=by_hex)
+        self.set_property(title, "remove", "maximized_horz", matchClass=matchClass, by_hex=by_hex)
+        #resize and move window
+        self.resize_move(title, x_offset+top_x, y_offset+top_y, win_width, win_height, matchClass=matchClass, by_hex=by_hex)
+
+    def _run_xrandr(self, args):
+        try:
+            with subprocess.Popen(["xrandr"] + args, stdout=subprocess.PIPE) as p:
+                output = p.communicate()[0].decode()[:-1]
+                returncode = p.returncode
+        except FileNotFoundError:
+            return 1, "ERROR: Please install xrandr"
+
+        return returncode, output
+
+    def _run_wmctrl(self, args):
+        try:
+            with subprocess.Popen(["wmctrl"] + args, stdout=subprocess.PIPE) as p:
+                output = p.communicate()[0].decode()[:-1]  # Drop trailing newline
+                returncode = p.returncode
+        except FileNotFoundError:
+            return 1, 'ERROR: Please install wmctrl'
+
+        return returncode, output
+
+    def get_window_list(self, filter_desktop=-1):
+        """
+        Returns a list of windows matching an optional desktop filter, requires C{wmctrl}!
+
+        Each list item consists of: C{[hexid, desktop, hostname, title]}
+
+        Where the C{hexid} is the ID used for some other functions (like L{import -window} from ImageMagick).
+
+        C{desktop} is the number of which desktop (sometimes called workspaces) the window appears upon.
+
+        C{hostname} is the hostname of your computer.
+
+        C{title} is the title that you would usually see in your window manager of choice.
+
+        @param filter_desktop: String, (usually 0-n) to filter the windows by. Any window not on the given desktop will not be returned.
+        @return: C{[[hexid1, desktop1, hostname1, title1], [hexid2,desktop2,hostname2,title2], ...etc]}
+        Returns C{[]} if no windows are found.
+        """
+        returncode, output = self._run_wmctrl(["-lG"])
+        matches = re.findall(WMCTRL_GEOM_REGEX, output, re.MULTILINE)
+        output = []
+        for match in matches:
+            hexid = match[0]
+            desktop = match[1]
+            hostname = match[6]
+            window_title = match[7]
+
+            if filter_desktop==desktop:
+                continue
+            output.append((hexid,desktop,hostname, window_title))
+        return output
+
+    def get_window_hex(self, title):
+        """
+        Returns the hexid of the first window to match title.
+
+        @param title: Window title to match for returning hexid
+        @return: Returns hexid of the window to be used for other functions See L{get_window_geom}, L{visgrep_by_window_id}
+
+        Returns C{None} if no matches are found
+        """
+        windowList = self.get_window_list()
+        for window in windowList:
+            if title in window[3]:
+                return window[0]
+        return None
+
+    def get_window_id(self, title):
+        return self.get_window_hex(title)
+
+
+    def get_window_geometry(self, title, by_hex=False):
+        """
+        Uses C{wmctrl} to return the window geometry of the given window title. Returns where the location of the
+        top left hand corner of the window is and the width/height of the window.
+
+
+        @param title
+        @return: C{[offsetx, offsety, sizex, sizey]} Returns none if no matches are found
+        """
+
+        index = -1 # by default use the window title for matching
+        if by_hex:
+            index = 0
+        if title == ":ACTIVE:":
+            if by_hex:
+                title = self.get_window_hex(self.get_active_title())
+            else:
+                title = self.get_active_title()
+        returncode, output = self._run_wmctrl(["-lG"])
+        matches = re.findall(WMCTRL_GEOM_REGEX, output, re.MULTILINE)
+        for match in matches:
+            if match[index] == title:
+                # trim hexid, gravity from front of list and the window title from end of list
+                # convert to ints and return
+                return list(map(int, match[2:-2]))
+        return None


### PR DESCRIPTION
# TLDR
With my recent discovery that I can poll the mouse location and interact with windows easily (on gnome shell at least) it opens the path toward (hopefully) easily port AutoKey over to full support on Wayland with minimal to no loss of major features

# STATUS
Abstracted Window interface, working with AutoKey gnome shell extension to get autokey working on Wayland/gnome distros (Ubuntu 22.04 for ex). 

The longer term plan is to have things setup internally so that we can easily add additional interfaces for different display servers and different desktop environments. 

https://github.com/sebastiansam55/autokey-gnome-extension

This GNOME shell extension is a fork of one that provides a number of dbus methods that allow us to interact with windows under wayland. We can get the active window information and move/resize/close/maximize/minimize. 

It will also allow us to poll the location of the mouse pointer, with this we can use uinput to move the mouse in x y until it is approximately in the correct location. TBD How hard that will actually be to make look smooth/fast. 

Unfortunately Wayland does not allow the pointer to be warped.


# TODO

- [ ] Add checking that Autokey Gnome Extension is properly installed
- [ ] Add config file/settings option to set window interface
- [x] ~~Add additional dbus functions to extension for mouse interactions~~ Wayland does not allow anything other than polling location
- [ ] Abstract mouse interface
- [ ] implement mouse movement via uinput events
- [ ] implement mouse clicks
- [ ] finalize and publish gnome shell extension
- [ ] update tests for window and other files
- [ ] kde has plasma extensions but I need to do more research on it.
 
Something needs to be done about the Button and Key classes in model. They need to be abstracted in someway that will allow `Key.LEFT` to correspond to the correct scan code/key code per the active keyboard system. 

# New

## uinput events
For hotkeys, under uinput we should be able to capture **any event**, so everything from foot peddles to mouse buttons, gamepads and keyboards we should be able to record and listen for as an event for a hotkey. Very cool.

## left/right modifiers
I am also going to strive to bring left and right differention to both the hotkey modifiers and the keyboard send system, have to either bring support for that to x11 keyboard or make it backwards compatible. Setting the generic version to left makes the most sense.

IE: For x11 there is currently only `Key.SHIFT` with no diffentiotion between left/right. For uinput I'll be trying to set it to respect all `Key.LSHIFT` `Key.RSHIFT` and `Key.SHIFT`. the last would be sent as left shift


## internal changes
Mouse, Keyboard, window interfaces are all going to be separated out to be independent of each other, with this done it will be easier to implement support for Wayland.



# Scenarios:

## GNOME/Wayland
- [x] windows via GNOME extension
- [ ] keyboard
  - [ ] read
  - [ ] write
- [ ] mouse
  - [x] read via GNOME extensions
  - [ ] write

## KDE/wayland
- [ ] windows via plasma/KDE extension?
- [ ] keyboard
  - [ ] read
  - [ ] write
- [ ] mouse
  - [ ] read
  - [ ] write

## [GNOME / KDE]/x11
- [x] windows
- [x] keyboard
  - [x] read
  - [x] write
- [x] mouse
  - [x] read
  - [x] write



# CHANGES 
`window` is going to change scripting API wise, will be breaking change, ultimately it's my fault for not being forward looking when adding those methods, they were tightly specific to x11

`mouse` will likely evolve, right now there's really only move and click but you don't send a click or don't send a move if you don't want to do both, would like to split those out