### PR TITLE
Bump version in /lib/autokey/common on develop branch

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,8 @@ Important misc changes
 - Update date, formatting, and NAME section in the GTK and Qt man pages.
 - Fix typo: Replace all occurrences of "they key" with "the key" in the AutoKey documentation.
 - Bump the AutoKey version to 0.96.1 in the **autokey.spec** file to satisfy part of issue #227.
+- Bump the version in the `/lib/autokey/common.py` file on the **develop** branch to 0.96.0-beta.11.
+
 
 Features
 ---------

--- a/lib/autokey/common.py
+++ b/lib/autokey/common.py
@@ -34,7 +34,7 @@ LOCK_FILE = os.path.join(RUN_DIR, "autokey.pid")
 
 APP_NAME = "autokey"
 CATALOG = ""
-VERSION = "0.96.0-beta.9"
+VERSION = "0.96.0-beta.11"
 HOMEPAGE = "https://github.com/autokey/autokey"
 AUTHOR = 'Chris Dekter'
 AUTHOR_EMAIL = 'cdekter@gmail.com'


### PR DESCRIPTION
Bump the version in the [/lib/autokey/common.py](https://github.com/autokey/autokey/blob/develop/lib/autokey/common.py) file on the **develop** branch to **0.96.0-beta.11**.