### PR TITLE
Update CHANGELOG.rst - fix #1027 by updating section headers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,7 @@ Other
 +++++
 - Add `show_recent_script_errors_dialog` to display errors with millisecond precision.
 - Add **Environment** as an issue type in the `bug.yml` file.
+- Fix two out-of-sequence section headers in CHANGELOG.rst to satisfy issue #1027.
 
 Version 0.96.0
 ============================
@@ -46,7 +47,7 @@ Features
 ---------
 
 Scripting API
-^^^^^^^^^^^^^
++++++++++++++
 
 **engine API object**
 
@@ -220,7 +221,7 @@ Features
 ---------
 
 Scripting API
-^^^^^^^^^^^^^
++++++++++++++
 
 **engine API object**
 


### PR DESCRIPTION
Fix the two out-of-sequence section headers in CHANGELOG.rst at [line 49](https://github.com/autokey/autokey/blob/87ace10981b00bee1e5069fb7b1b5da9770a80bb/CHANGELOG.rst#L49) and [line 223](https://github.com/autokey/autokey/blob/87ace10981b00bee1e5069fb7b1b5da9770a80bb/CHANGELOG.rst#L223) to satisfy issue #1027.
