### PR TITLE
docs: update autokey-run man page format and add SEE ALSO section

### DIFF
--- a/doc/man/autokey-run.1
+++ b/doc/man/autokey-run.1
@@ -1,9 +1,14 @@
 .\"                                      Hey, EMACS: -*- nroff -*-
+.\" Please adjust this date whenever revising the man page:
+.TH AUTOKEY-RUN "1" "November 29, 2025"
+.\"
 .\" First parameter, NAME, should be all caps.
 .\" Second parameter, SECTION, should be 1-8, maybe w/ subsection.
 .\" Other parameters are allowed: see man(7), man(1).
-.TH AUTOKEY-RUN "1" "April 19, 2023"
-.\" Please adjust this date whenever revising the man page.
+.\"
+.\" TeX users may be more comfortable with the \fB<whatever>\fR and
+.\" \fI<whatever>\fR escape sequences to invoke bold-face or italics,
+.\" respectively.
 .\"
 .\" Some roff macros for reference:
 .\" .nh        disable hyphenation
@@ -15,41 +20,98 @@
 .\" .br        insert line break
 .\" .sp <n>    insert n+1 empty lines
 .\" For man-page-specific macros, see man(7).
+
 .SH NAME
-autokey-run \- command-line execution utility for AutoKey
+\fBautokey-run\fR \- command-line execution utility for AutoKey
+
 .SH SYNOPSIS
-.B autokey-run
-.RI -[s|p|f] [name]
+\fBautokey-run\fR -[\fIf|h|p|s\fR] [\fIname\fR]
+
 .SH DESCRIPTION
-This manual page briefly documents the \fBautokey-run\fP command.
-.PP
-.\" TeX users may be more comfortable with the \fB<whatever>\fP and
-.\" \fI<whatever>\fP escape sequences to invoke bold-face or italics,
-.\" respectively.
-\fBautokey-run\fP is a command-line execution utility for AutoKey that
+\fBautokey-run\fR is a command-line execution utility for AutoKey that
 allows you to initiate execution of folders, phrases, or scripts from
 the command line.
-.PP
-See the online wiki at https://github.com/autokey/autokey/wiki for more
-information.
+
 .SH OPTIONS
 This program follows the usual GNU command-line syntax in which long
 options start with two dashes (`--').
 A summary of options is included below.
 .TP
-.B \-f, \-\-folder [name]
+.B \-f, \-\-folder [\fIname\fR]
 Display a pop-up menu for the specified folder.
 .TP
 .B \-h, \-\-help
 Show a summary of all options.
 .TP
-.B \-p, \-\-phrase [name]
+.B \-p, \-\-phrase [\fIname\fR]
 Paste a phrase with the specified name.
 .TP
-.B \-s, \-\-script [name]
-Run a script with the specified name.
+.B \-s, \-\-script [\fIname\fR]
+Run a script with the specified name. Accepts full paths to Python
+scripts. If no full path is given, will treat the name as an existing
+AutoKey script name instead.
+
 .SH AUTHOR
-AutoKey was written by Chris Dekter and was loosely based on a script by
-Sam Peterson.
-.PP
-This manual page was written by Chris Dekter <cdekter@gmail.com>.
+AutoKey was written by Chris Dekter <cdekter@gmail.com> and was loosely
+based on a script by Sam Peterson.
+
+.SH SEE ALSO
+.TP
+\fBautokey-gtk\fR(1), \fBautokey-qt\fR(1), \fBpython\fR(1), \fBwmctrl\fR(1), \fBxautomation\fR(7), \fBxdotool\fR(1), \fBxmodmap\fR(1), \fBzenity\fR(1)
+.TP
+\fBRelated software:\fR
+.RS
+.IP \[bu] 2
+\fBcutelog:\fR https://github.com/busimus/cutelog
+.IP \[bu] 2
+\fBRegular expression syntax:\fR https://docs.python.org/3/library/re.html
+.IP \[bu] 2
+\fBRegular expression tutorial:\fR https://docs.python.org/3/howto/regex.html
+.IP \[bu] 2
+\fBXKB:\fR https://www.x.org/releases/current/doc/xorg-docs/input/XKB-Config.html
+.RE
+.TP
+\fBSimilar software in other operating systems:\fR
+.RS
+.IP \[bu] 2
+\fBAutoHotKey\fR is a free and open-source tool available for Microsoft
+Windows users.
+.IP \[bu] 2
+\fBAutomator\fR is a default Apple tool.
+.IP \[bu] 2
+\fBText Replacement\fR is a default Apple tool.
+.RE
+.TP
+\fBAutoKey web pages:\fR
+.RS
+.IP \[bu] 2
+\fBDocumentation:\fR
+.RS
+.IP \[bu] 2
+\fBAutoKey 0.95.0 through 0.95.10:\fR https://autokey.github.io/autokey/index.html
+.IP \[bu] 2
+\fBAutoKey 0.96.0 and newer:\fR https://autokey.github.io/index.html
+.RE
+.IP \[bu] 2
+\fBHome:\fR https://github.com/autokey/autokey
+.IP \[bu] 2
+\fBIssues:\fR https://github.com/autokey/autokey/issues
+.IP \[bu] 2
+\fBSocial:\fR
+.RS
+.IP \[bu] 2
+\fBDiscord:\fR https://github.com/autokey/autokey/wiki/Discord
+.IP \[bu] 2
+\fBDiscussions:\fR https://github.com/autokey/autokey/discussions
+.IP \[bu] 2
+\fBGitter:\fR https://github.com/autokey/autokey/wiki/Gitter
+.IP \[bu] 2
+\fBGoogle Groups:\fR https://github.com/autokey/autokey/wiki/Google-Groups
+.IP \[bu] 2
+\fBReddit:\fR https://github.com/autokey/autokey/wiki/Reddit
+.IP \[bu] 2
+\fBStackExchange:\fR https://github.com/autokey/autokey/wiki/StackExchange
+.RE
+.IP \[bu] 2
+\fBWiki:\fR https://github.com/autokey/autokey/wiki
+.RE


### PR DESCRIPTION
## Summary

Updates the `autokey-run` man page to match the format used in the updated `autokey-gtk` and `autokey-qt` man pages.

### Changes

- Updated header format and date to match other man pages
- Added comprehensive **SEE ALSO** section with:
  - Related commands (autokey-gtk, autokey-qt, python, wmctrl, etc.)
  - Related software links (cutelog, regex docs, XKB)
  - Similar software in other operating systems
  - AutoKey web pages and documentation links
- Documented that `--script` option accepts full paths to Python scripts (feature added in AutoKey 0.96.0)
- Improved formatting consistency using `\fB` and `\fR` escapes

### Preview

```
AUTOKEY-RUN(1)              General Commands Manual             AUTOKEY-RUN(1)

NAME
       autokey-run - command-line execution utility for AutoKey

...

       -s, --script [name]
              Run a script with the specified name. Accepts full paths to
              Python scripts. If no full path is given, will treat the name
              as an existing AutoKey script name instead.

SEE ALSO
       autokey-gtk(1), autokey-qt(1), python(1), wmctrl(1), xautomation(7),
       xdotool(1), xmodmap(1), zenity(1)
...
```

Fixes #869