### PR TITLE
Show a clear error on Wayland without X11

### DIFF
--- a/lib/autokey/UI_common_functions.py
+++ b/lib/autokey/UI_common_functions.py
@@ -78,6 +78,21 @@ def checkRequirements():
     return errorMessage
 
 
+def get_wayland_error_message():
+    session_type = os.environ.get('XDG_SESSION_TYPE', '').lower()
+    has_wayland_display = bool(os.environ.get('WAYLAND_DISPLAY'))
+    has_x11_display = bool(os.environ.get('DISPLAY'))
+
+    if (session_type == 'wayland' or has_wayland_display) and not has_x11_display:
+        return (
+            "Wayland session detected but no X11 display is available. "
+            "AutoKey currently requires X11. Please run under an X11 session "
+            "or enable XWayland."
+        )
+
+    return ""
+
+
 def create_storage_directories():
     """Create various storage directories, if those do not exist."""
     # Create configuration directory

--- a/lib/autokey/gtkapp.py
+++ b/lib/autokey/gtkapp.py
@@ -78,6 +78,13 @@ class Application:
             Gdk.threads_leave()
             sys.exit("Missing required programs and/or python modules, exiting")
 
+        wayland_error = UI_common.get_wayland_error_message()
+        if wayland_error:
+            Gdk.threads_enter()
+            self.show_error_dialog("AutoKey requires X11 to run.", wayland_error)
+            Gdk.threads_leave()
+            sys.exit(1)
+
         try:
             create_storage_directories()
 

--- a/lib/autokey/qtapp.py
+++ b/lib/autokey/qtapp.py
@@ -112,6 +112,11 @@ class Application(QApplication):
             self.show_error_dialog("AutoKey Requires the following programs or python modules to be installed to function properly\n\n"+missing_reqs)
             sys.exit("Missing required programs and/or python modules, exiting")
 
+        wayland_error = UI_common.get_wayland_error_message()
+        if wayland_error:
+            self.show_error_dialog("AutoKey requires X11 to run.", wayland_error)
+            sys.exit(1)
+
         logger.info("Initialising application")
         self.setWindowIcon(QIcon.fromTheme(common.ICON_FILE, ui_common.load_icon(ui_common.AutoKeyIcon.AUTOKEY)))
         try:


### PR DESCRIPTION
Detect Wayland sessions without an X11 display and show a clear error explaining that AutoKey currently requires X11/XWayland. This avoids opaque startup failures.