### PR TITLE
Fix regex strings

### DIFF
--- a/lib/autokey/model/abstract_abbreviation.py
+++ b/lib/autokey/model/abstract_abbreviation.py
@@ -140,7 +140,7 @@ class AbstractAbbreviation:
 
             # Check chars ahead of abbr
             # length of stringBefore should always be > 0
-            if len(stringBefore) > 0 and not re.match('(^\s)', stringBefore[-1]) and not self.triggerInside:
+            if len(stringBefore) > 0 and not re.match(r'(^\s)', stringBefore[-1]) and not self.triggerInside:
                 # check if last char before the typed abbreviation is a word char
                 # if triggerInside is not set, can't trigger when inside a word
                 return False

--- a/lib/autokey/model/helpers.py
+++ b/lib/autokey/model/helpers.py
@@ -18,7 +18,7 @@ import enum
 import os
 import re
 
-DEFAULT_WORDCHAR_REGEX = '[\w]'
+DEFAULT_WORDCHAR_REGEX = r'[\w]'
 JSON_FILE_PATTERN = "{}/{}.json"
 SPACES_RE = re.compile(r"^ | $")
 

--- a/lib/autokey/model/key.py
+++ b/lib/autokey/model/key.py
@@ -119,7 +119,7 @@ _ALL_MODIFIERS_ = (
 
 # Used to identify special keys in texts. Also include <codeXX> literals as defined in the _code_point_re.
 KEY_FIND_RE = re.compile("|".join(("|".join(Key), _code_point_re.pattern)), re.UNICODE)
-KEY_SPLIT_RE = re.compile("(<[^<>]+>\+?)")
+KEY_SPLIT_RE = re.compile(r"(<[^<>]+>\+?)")
 MODIFIERS = [Key.CONTROL, Key.ALT, Key.ALT_GR, Key.SHIFT, Key.SUPER, Key.HYPER, Key.META, Key.CAPSLOCK, Key.NUMLOCK]
 HELD_MODIFIERS = [Key.CONTROL, Key.ALT_GR, Key.ALT, Key.SUPER, Key.SHIFT, Key.HYPER, Key.META
 ]


### PR DESCRIPTION
I found these with `python -m compileall -q .`:
```
./lib/autokey/model/abstract_abbreviation.py:143: SyntaxWarning: "\s" is an invalid escape sequence. Such sequences will not work in the future. Did you mean "\\s"? A raw string is also an option.
  if len(stringBefore) > 0 and not re.match('(^\s)', stringBefore[-1]) and not self.triggerInside:
./lib/autokey/model/helpers.py:21: SyntaxWarning: "\w" is an invalid escape sequence. Such sequences will not work in the future. Did you mean "\\w"? A raw string is also an option.
  DEFAULT_WORDCHAR_REGEX = '[\w]'
./lib/autokey/model/key.py:122: SyntaxWarning: "\+" is an invalid escape sequence. Such sequences will not work in the future. Did you mean "\\+"? A raw string is also an option.
  KEY_SPLIT_RE = re.compile("(<[^<>]+>\+?)")
```

Edit: Oh, there was already an issue for this...
Fixes #536 