### PR TITLE
Fix: Skip grab/ungrab for keys not in current keymap (keycode 0)

### DIFF
--- a/lib/autokey/interface.py
+++ b/lib/autokey/interface.py
@@ -757,6 +757,11 @@ class XInterfaceBase(threading.Thread, AbstractMouseInterface):
                      un, modifiers, key)
         try:
             keycode = self.__lookupKeyCode(key)
+            if keycode == 0:
+                # Keysym has no keycode in the current keymap (keysym_to_keycode returned 0).
+                # Avoid calling grab_key/ungrab_key with keycode 0 (AnyKey) which would grab all keys.
+                logger.debug("Skipping grab/ungrab for key %r: keysym maps to keycode 0 (not present in current keymap)", key)
+                return
             masks = self.__build_modifier_mask(modifiers)
             for mask in masks:
                 if grab:


### PR DESCRIPTION
## Summary

Fixes #1066

This PR fixes a bug where AutoKey would absorb all keyboard input when a script was assigned to a key that doesn't exist in the current xkb keyboard configuration.

## Problem

When a user assigns a script to a key that is not defined in the current xkb configuration, AutoKey attempts to grab the key using . In X11, keycode 0 is defined as `AnyKey`, which causes AutoKey to grab **all keyboard input**, rendering the keyboard unusable except for triggering the assigned script.

## Root Cause

In `__grab_ungrab_hotkey()` function in `lib/autokey/interface.py`:
- `__lookupKeyCode(key)` returns 0 for keys not present in the current xkb configuration
- This 0 keycode is then passed to `window.grab_key()`
- X11 interprets keycode 0 as `AnyKey`, grabbing all keys

## Solution

Add a check after looking up the keycode:
- If keycode is 0, skip the grab/ungrab operation
- Log a debug message to inform users that the key is not present in the current keymap
- This prevents the `AnyKey` grab issue

## Testing

The fix was proposed and validated by @OlliL in issue #1066 after extensive debugging.

## Changes

- Modified `lib/autokey/interface.py` to add keycode 0 check in `__grab_ungrab_hotkey()` function
- Added informative debug log message when skipping grab/ungrab

## Impact

- Prevents keyboard lockup when using custom keyboard layouts with undefined keys
- Maintains normal functionality for all valid key assignments
- Minimal code change with clear safety benefit

Huge thanks to @OlliL for the detailed debugging and analysis!