### PR TITLE
fix: get version from common.py instead of git tags in debian/build.sh

### DIFF
--- a/debian/build.sh
+++ b/debian/build.sh
@@ -3,7 +3,7 @@
 [ -f debian/build_requirements.txt ] && \
   cat debian/build_requirements.txt | xargs sudo apt-get install -y
 
-VERSION=$(git describe --tags --abbrev=0 --match "v*.*.*")
+VERSION=$(python3 -c "from lib.autokey.common import VERSION; print(VERSION)" 2>/dev/null)
 # Strip leading 'v' because that is invalid as a debian version number
 DEBVERSION="${VERSION#?}"
 uscan -dd


### PR DESCRIPTION
Fixed version detection in debian/build.sh
The build script currently was using git describe --tags --abbrev=0 --match "v*.."

This can lead to incorrect version used because tags (vX.X.X-beta.X) are not matched properly.

This changes directly retrives the version from lib/autokey/common.py, ensuring correct version is been used while building debian package.

Fixes #1082