### PR TITLE
fix(build): extract version from common.py and handle v-prefix safely

### DIFF
--- a/debian/build.sh
+++ b/debian/build.sh
@@ -3,12 +3,18 @@
 [ -f debian/build_requirements.txt ] && \
   cat debian/build_requirements.txt | xargs sudo apt-get install -y
 
-VERSION=$(git describe --tags --abbrev=0 --match "v*.*.*")
-# Strip leading 'v' because that is invalid as a debian version number
-DEBVERSION="${VERSION#?}"
+VERSION=$(python3 -c "import sys; sys.path.insert(0, '.'); from lib.autokey.common import VERSION; print(VERSION)")
+
+if [ -z "$VERSION" ]; then
+    echo "FATAL: Could not extract VERSION from lib/autokey/common.py" >&2
+    exit 1
+fi
+
+# Strip leading 'v' if present, safe no-op when absent
+DEBVERSION="${VERSION#v}"
 uscan -dd
 # Create fake changelog entry just to get the correct version number on the deb
-dch --newversion "$DEBVERSION" ""
+dch --newversion "$DEBVERSION-1" "Local build for testing"
 dpkg-buildpackage -i --build=binary --unsigned-source
 
 # # Update PPA. Requires more in-depth packaging.


### PR DESCRIPTION
Fixes #1082

**Cause:**
- `git describe --tags` returns the old release tag after a cycle reset,
causing `.deb` packages to build with the wrong version.
- `${VERSION#?}` blindly stripped the first character, corrupting versions
without a leading `v` (e.g. `0.96.0` into `.96.0`).

**Changes made:**
- Version is now read directly from `lib/autokey/common.py`.
- Hard exit if extraction fails.
- `${VERSION#?}` replaced with `${VERSION#v}`.

**Tested:**
- Verified `python3` extraction returns `0.96.0` correctly from `lib/autokey/common.py`.
- Verified empty VERSION check exits with code 1.

```bash
# Correct extraction
$ python3 -c "import sys; sys.path.insert(0, '.'); from lib.autokey.common import VERSION; print(VERSION)"
0.96.0

# fail on broken import
$ python3 -c "import sys; sys.path.insert(0, '.'); from lib.autokey.common import VERSION_BROKEN; print(VERSION_BROKEN)"
ImportError: cannot import name 'VERSION_BROKEN'
Exit code: 1