### PR TITLE
Fix intermittent RuntimeError caused by concurrent X11 display access

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -71,6 +71,7 @@ Bug fixes
 - Fix fake keyboard events not being emitted in a timely manner in some cases
 - Upgrade the **develop** branch to satisfy issue #773.
 - Fix selection when cloning a phrase or script
+- Fixed intermittent python-xlib RuntimeError caused by concurrent thread access to the X11 display.
 
 Other changes
 -------------

--- a/lib/autokey/interface.py
+++ b/lib/autokey/interface.py
@@ -117,19 +117,21 @@ class XWindowInterface(AbstractWindowInterface):
 
     def __init__(self):
         self.localDisplay = display.Display()
+        self.xlib_lock = threading.Lock()
         # Window name atoms
         self.__NameAtom = self.localDisplay.intern_atom("_NET_WM_NAME", True)
         self.__VisibleNameAtom = self.localDisplay.intern_atom("_NET_WM_VISIBLE_NAME", True)
 
 
     def get_window_info(self, window=None, traverse: bool=True) -> WindowInfo:
-        try:
-            if window is None:
-                window = self.localDisplay.get_input_focus().focus
-            return self._get_window_info(window, traverse)
-        except error.BadWindow:
-            logger.warning("Got BadWindow error while requesting window information.")
-            return self._create_window_info(window, "", "")
+        with self.xlib_lock:
+            try:
+                if window is None:
+                    window = self.localDisplay.get_input_focus().focus
+                return self._get_window_info(window, traverse)
+            except error.BadWindow:
+                logger.warning("Got BadWindow error while requesting window information.")
+                return self._create_window_info(window, "", "")
 
     def get_window_title(self, window=None, traverse=True) -> str:
         return self.get_window_info(window, traverse).wm_title
@@ -255,6 +257,7 @@ class XInterfaceBase(threading.Thread, AbstractMouseInterface):
 
         self.eventThread.start()
         self.listenerThread.start()
+        self.xlib_lock = threading.Lock()
 
     @queue_method(queue)
     def flush(self):
@@ -451,15 +454,17 @@ class XInterfaceBase(threading.Thread, AbstractMouseInterface):
         :return: Tuple of the Mouse Location(x,y)
         :rtype: tuple
         """
-        pos = self.rootWindow.query_pointer()
-        return (pos.root_x, pos.root_y)
+        with self.xlib_lock:
+            pos = self.rootWindow.query_pointer()
+            return (pos.root_x, pos.root_y)
 
     def relative_mouse_location(self, window=None):
         #return relative mouse location within given window
-        if window==None:
-            window = self.localDisplay.get_input_focus().focus
-        pos = window.query_pointer()
-        return (pos.win_x, pos.win_y)
+        with self.xlib_lock:
+            if window==None:
+                window = self.localDisplay.get_input_focus().focus
+            pos = window.query_pointer()
+            return (pos.win_x, pos.win_y)
 
     def scroll_down(self, number):
         for i in range(0, number):


### PR DESCRIPTION
Fixes #1064
When AutoKey scripts call window.get_active_title() or mouse.get_location() concurrently with other X11 operations, python-xlib's internal request/reply tracking breaks, raising RuntimeError: 'Request reply to unknown request'.

Fix by protecting synchronous Xlib calls in XInterfaceBase with a threading.Lock(), ensuring only one thread performs round-trip X11 requests at a time.