### PR TITLE
wayland: align window interface contract across backends

### DIFF
--- a/lib/autokey/interface.py
+++ b/lib/autokey/interface.py
@@ -136,6 +136,24 @@ class XWindowInterface(AbstractWindowInterface):
 
     def get_window_class(self, window=None, traverse=True) -> str:
         return self.get_window_info(window, traverse).wm_class
+
+    def get_screen_size(self):
+        screen = self.localDisplay.screen()
+        return [int(screen.width_in_pixels), int(screen.height_in_pixels)]
+
+    def get_active_window(self):
+        window = self.localDisplay.get_input_focus().focus
+        info = self.get_window_info(window)
+        geom = window.get_geometry()
+        return {
+            "id": getattr(window, "id", None),
+            "wm_class": info.wm_class,
+            "wm_title": info.wm_title,
+            "x": int(geom.x),
+            "y": int(geom.y),
+            "width": int(geom.width),
+            "height": int(geom.height),
+        }
     
     def _get_window_info(self, window, traverse: bool, wm_title: str=None, wm_class: str=None) -> WindowInfo:
         new_wm_title = self._try_get_window_title(window)

--- a/lib/autokey/sys_interface/abstract_interface.py
+++ b/lib/autokey/sys_interface/abstract_interface.py
@@ -147,12 +147,25 @@ class AbstractWindowInterface(ABC, metaclass=ABCMeta):
     @abstractmethod
     def get_window_info(self, window=None, traverse: bool=True) -> WindowInfo:
         return
+
     @abstractmethod
     def get_window_list(self):
         return
+
     @abstractmethod
     def get_window_title(self, window=None, traverse=True) -> str:
         return
+
     @abstractmethod
     def get_window_class(self, window=None, traverse=True) -> str:
+        return
+
+    @abstractmethod
+    def get_screen_size(self):
+        """Return current screen size as [width, height]."""
+        return
+
+    @abstractmethod
+    def get_active_window(self):
+        """Return active window descriptor used by platform specific APIs."""
         return


### PR DESCRIPTION
## Summary
This is a focused first step toward #87 (Wayland support): align window interface contract across backends to reduce X11/Wayland drift.

## What changed
- Added missing abstract methods to `AbstractWindowInterface`:
  - `get_screen_size()`
  - `get_active_window()`
- Implemented the same methods in X11 backend (`XWindowInterface`) for parity with Wayland usage paths.

## Why this helps Wayland work
Wayland paths already rely on these window interface capabilities. Defining and implementing them consistently at the abstract/backend layer prevents backend divergence and makes subsequent Wayland work safer and more reviewable.

## Validation
- `python3 -m py_compile` passed on modified/dependent files.

Refs: #87
