### PR TITLE
wayland: harden uinput path and avoid GNOME DBus hard-fail (#87)

### DIFF
--- a/lib/autokey/gnome_interface.py
+++ b/lib/autokey/gnome_interface.py
@@ -50,21 +50,24 @@ class GnomeExtensionWindowInterface(DBusInterface, AbstractWindowInterface):
         """
         Returns a WindowInfo object containing the class and title.
         """
-        window = self._active_window()
-        return WindowInfo(wm_class=window['wm_class'], wm_title=window['wm_title'])
+        active = self._active_window()
+        if not active:
+            return WindowInfo(wm_class="", wm_title="")
+        return WindowInfo(wm_class=active.get('wm_class', ''), wm_title=active.get('wm_title', ''))
 
     def get_window_class(self, window=None, traverse=True) -> str:
         """
         Returns the window class of the currently focused window.
         """
-        return self._active_window()['wm_class']
-        
-    
+        active = self._active_window()
+        return active.get('wm_class', '') if active else ''
+
     def get_window_title(self, window=None, traverse=True) -> str:
         """
         Returns the active window title
         """
-        return self._active_window()['wm_title']
+        active = self._active_window()
+        return active.get('wm_title', '') if active else ''
     
     def close_window(self, window_id):
         self._dbus_close_window(window_id)

--- a/lib/autokey/iomediator/iomediator.py
+++ b/lib/autokey/iomediator/iomediator.py
@@ -23,6 +23,7 @@ from autokey import common
 from autokey.configmanager.configmanager import ConfigManager
 from autokey.configmanager.configmanager_constants import INTERFACE_TYPE
 from autokey.gnome_interface import GnomeExtensionWindowInterface
+from autokey.sys_interface.abstract_interface import WindowInfo
 from autokey.sys_interface.clipboard import Clipboard
 from autokey.model.phrase import SendMode
 
@@ -33,6 +34,28 @@ from .constants import X_RECORD_INTERFACE
 CURRENT_INTERFACE = None
 
 logger = __import__("autokey.logger").logger.get_logger(__name__)
+
+
+class _NullWindowInterface:
+    """Fallback for Wayland sessions when desktop-specific DBus integration is unavailable."""
+
+    def get_window_info(self, window=None, traverse=True):
+        return WindowInfo(wm_title="", wm_class="")
+
+    def get_window_class(self, window=None, traverse=True):
+        return ""
+
+    def get_window_title(self, window=None, traverse=True):
+        return ""
+
+    def get_window_list(self):
+        return []
+
+    def get_screen_size(self):
+        return [1920, 1080]
+
+    def get_active_window(self):
+        return None
 
 
 class IoMediator(threading.Thread):
@@ -71,7 +94,11 @@ class IoMediator(threading.Thread):
         
         if self.interfaceType == "uinput":
             logger.debug("Using gnome extension window interface")
-            self.windowInterface = GnomeExtensionWindowInterface()
+            try:
+                self.windowInterface = GnomeExtensionWindowInterface()
+            except Exception as e:
+                logger.warning("Failed to initialize GNOME Wayland window interface, using null window info fallback: %s", e)
+                self.windowInterface = _NullWindowInterface()
         else:
             from autokey.interface import XWindowInterface
             self.windowInterface = XWindowInterface()

--- a/lib/autokey/uinput_interface.py
+++ b/lib/autokey/uinput_interface.py
@@ -26,7 +26,7 @@ from autokey.autokey_app import AutokeyApplication
 
 logger = __import__("autokey.logger").logger.get_logger(__name__)
 
-from autokey.sys_interface.abstract_interface import AbstractSysInterface, AbstractMouseInterface, queue_method
+from autokey.sys_interface.abstract_interface import AbstractSysInterface, AbstractMouseInterface, WindowInfo, queue_method
 import autokey.configmanager.configmanager as cm
 import autokey.configmanager.configmanager_constants as cm_constants
 from autokey.gnome_interface import GnomeMouseReadInterface
@@ -370,8 +370,11 @@ class UInputInterface(threading.Thread, GnomeMouseReadInterface, AbstractSysInte
         mousex,mousey = self.mouse_location()
         if window is None:
             window = self.mediator.windowInterface.get_active_window()
-        winx = window.get('x')
-        winy = window.get('y')
+        if not window:
+            logger.warning("relative_mouse_location: active window unavailable, returning absolute coordinates")
+            return (mousex, mousey)
+        winx = int(window.get('x', 0))
+        winy = int(window.get('y', 0))
         relx = mousex - winx
         rely = mousey - winy
 
@@ -635,7 +638,11 @@ class UInputInterface(threading.Thread, GnomeMouseReadInterface, AbstractSysInte
     
     @queue_method(queue)
     def handle_keypress(self, keyCode):
-        window_info = self.mediator.windowInterface.get_window_info()
+        try:
+            window_info = self.mediator.windowInterface.get_window_info()
+        except Exception as e:
+            logger.warning("handle_keypress: failed to fetch window info: %s", e)
+            window_info = WindowInfo(wm_title="", wm_class="")
         event_type = evdev.categorize(keyCode)
         logger.debug("handle_keypress: KeyState:{}, Un:{}".format(event_type.keystate, event_type.keycode))
         if self.isModifier(event_type.keycode):
@@ -647,7 +654,11 @@ class UInputInterface(threading.Thread, GnomeMouseReadInterface, AbstractSysInte
 
     @queue_method(queue)
     def handle_keyrelease(self, keyCode):
-        window_info = self.mediator.windowInterface.get_window_info()
+        try:
+            window_info = self.mediator.windowInterface.get_window_info()
+        except Exception as e:
+            logger.warning("handle_keyrelease: failed to fetch window info: %s", e)
+            window_info = WindowInfo(wm_title="", wm_class="")
         event_type = evdev.categorize(keyCode)
         logger.debug("handle_keyrelease: KeyState:{}, Un:{}".format(event_type.keystate, event_type.keycode))
         if self.isModifier(event_type.keycode):


### PR DESCRIPTION
## Summary
Bounty-focused Wayland follow-up for #87.

This PR targets practical Wayland support behavior in real sessions by hardening the uinput path and removing hard failures when GNOME DBus window integration is unavailable.

## What this changes

### 1) Wayland uinput startup no longer hard-fails if GNOME DBus extension is missing
- In `IoMediator`, initializing `GnomeExtensionWindowInterface()` is now guarded.
- If GNOME DBus integration is unavailable, AutoKey falls back to a null window interface instead of failing startup.

### 2) Safe fallback window metadata path for Wayland
- Added `_NullWindowInterface` fallback implementation with safe defaults.
- Provides:
  - empty `WindowInfo` (`wm_title`, `wm_class`) instead of exceptions
  - safe screen size default
  - no active-window assumptions

### 3) Defensive handling in uinput event path
- `handle_keypress` / `handle_keyrelease` now guard window info retrieval and use empty `WindowInfo` on failure.
- `relative_mouse_location()` now handles missing active window safely and returns absolute coordinates instead of crashing.

### 4) GNOME window interface hardening
- `GnomeExtensionWindowInterface` now safely handles missing active-window state and returns empty metadata strings rather than throwing.

## Why this is relevant to #87
On Wayland, many users run into runtime failures due to compositor/desktop-specific window APIs. This PR makes AutoKey continue operating (key processing/uinput path) even when GNOME-specific window metadata integration is unavailable or transiently failing.

This is an implementation-focused reliability step toward real Wayland usability, rather than a warning-only change.

## Validation
- `python3 -m py_compile` passed for:
  - `lib/autokey/iomediator/iomediator.py`
  - `lib/autokey/uinput_interface.py`
  - `lib/autokey/gnome_interface.py`

Refs: #87
