### PR TITLE
feat: Wayland compositor detection and graceful fallback for non-GNOME compositors

### DIFF
--- a/lib/autokey/gnome_interface.py
+++ b/lib/autokey/gnome_interface.py
@@ -51,20 +51,28 @@ class GnomeExtensionWindowInterface(DBusInterface, AbstractWindowInterface):
         Returns a WindowInfo object containing the class and title.
         """
         window = self._active_window()
+        if window is None:
+            return WindowInfo(wm_class="", wm_title="")
         return WindowInfo(wm_class=window['wm_class'], wm_title=window['wm_title'])
 
     def get_window_class(self, window=None, traverse=True) -> str:
         """
         Returns the window class of the currently focused window.
         """
-        return self._active_window()['wm_class']
+        active = self._active_window()
+        if active is None:
+            return ""
+        return active['wm_class']
         
     
     def get_window_title(self, window=None, traverse=True) -> str:
         """
         Returns the active window title
         """
-        return self._active_window()['wm_title']
+        active = self._active_window()
+        if active is None:
+            return ""
+        return active['wm_title']
     
     def close_window(self, window_id):
         self._dbus_close_window(window_id)

--- a/lib/autokey/iomediator/iomediator.py
+++ b/lib/autokey/iomediator/iomediator.py
@@ -22,7 +22,7 @@ import autokey
 from autokey import common
 from autokey.configmanager.configmanager import ConfigManager
 from autokey.configmanager.configmanager_constants import INTERFACE_TYPE
-from autokey.gnome_interface import GnomeExtensionWindowInterface
+from autokey.wayland_compositor import create_wayland_window_interface, detect_wayland_compositor, COMPOSITOR_GNOME
 from autokey.sys_interface.clipboard import Clipboard
 from autokey.model.phrase import SendMode
 
@@ -70,8 +70,8 @@ class IoMediator(threading.Thread):
             pass
         
         if self.interfaceType == "uinput":
-            logger.debug("Using gnome extension window interface")
-            self.windowInterface = GnomeExtensionWindowInterface()
+            logger.debug("Creating Wayland window interface")
+            self.windowInterface = create_wayland_window_interface()
         else:
             from autokey.interface import XWindowInterface
             self.windowInterface = XWindowInterface()
@@ -80,6 +80,9 @@ class IoMediator(threading.Thread):
         if self.interfaceType == "uinput":
             from autokey.uinput_interface import UInputInterface
             self.interface = UInputInterface(self, self.app)
+            # Wire up mouse reader if the window interface supports it
+            if hasattr(self.windowInterface, 'mouse_location'):
+                self.interface.set_mouse_reader(self.windowInterface)
         elif self.interfaceType == X_RECORD_INTERFACE:
             from autokey.interface import XRecordInterface
             self.interface = XRecordInterface(self, self.app)

--- a/lib/autokey/service.py
+++ b/lib/autokey/service.py
@@ -180,7 +180,10 @@ class Service:
 
     def handle_keypress(self, rawKey, modifiers, key, window_info):
         logger.debug("Raw key: %r, modifiers: %r, Key: %s", rawKey, modifiers, key)
-        logger.debug("Window visible title: %r, Window class: %r" % window_info)
+        if window_info is not None:
+            logger.debug("Window visible title: %r, Window class: %r" % window_info)
+        else:
+            logger.debug("Window info unavailable (compositor may not support window detection)")
         self.configManager.lock.acquire()
 
         # Check global hotkeys regardless of whether autokey is paused, because
@@ -371,6 +374,8 @@ class Service:
         """
         Return a boolean indicating whether we should take any action on the keypress
         """
+        if windowInfo is None:
+            return self.is_running()
         return windowInfo[0] != "Set Abbreviations" and self.is_running()
 
     def __processItem(self, item, buffer=''):

--- a/lib/autokey/sys_interface/abstract_interface.py
+++ b/lib/autokey/sys_interface/abstract_interface.py
@@ -89,6 +89,7 @@ class AbstractSysInterface(ABC, metaclass=ABCMeta):
     @abstractmethod
     def press_key(self, key_name):
         return
+    @abstractmethod
     def release_key(self, key_name):
         return
     @abstractmethod

--- a/lib/autokey/uinput_interface.py
+++ b/lib/autokey/uinput_interface.py
@@ -29,11 +29,11 @@ logger = __import__("autokey.logger").logger.get_logger(__name__)
 from autokey.sys_interface.abstract_interface import AbstractSysInterface, AbstractMouseInterface, queue_method
 import autokey.configmanager.configmanager as cm
 import autokey.configmanager.configmanager_constants as cm_constants
-from autokey.gnome_interface import GnomeMouseReadInterface
+
 
 #TODO when exiting the thread waits for one more signal and that signal repeats  for a bit during exit
 
-class UInputInterface(threading.Thread, GnomeMouseReadInterface, AbstractSysInterface):
+class UInputInterface(threading.Thread, AbstractSysInterface):
     """
     god this is complicated lol
     """
@@ -205,7 +205,9 @@ class UInputInterface(threading.Thread, GnomeMouseReadInterface, AbstractSysInte
             raise Exception
             #print("Unable to create UInput device. {}".format(ex))
 
-        GnomeMouseReadInterface.__init__(self)
+        # Mouse location reading is provided by the window interface
+        # (GNOME extension, or fallback). We delegate to it via the mediator.
+        self._mouse_reader = None
         logger.debug("Screen size: {}".format(self.mediator.windowInterface.get_screen_size()))
 
 
@@ -220,6 +222,25 @@ class UInputInterface(threading.Thread, GnomeMouseReadInterface, AbstractSysInte
 
         self.eventThread.start()
         self.listenerThread.start()
+
+    def set_mouse_reader(self, mouse_reader):
+        """Set the object used to read mouse position (e.g. GNOME extension DBus)."""
+        self._mouse_reader = mouse_reader
+
+    def mouse_location(self):
+        """
+        Get current mouse position.
+
+        Delegates to the compositor-specific mouse reader if available.
+        """
+        if self._mouse_reader is not None:
+            try:
+                return self._mouse_reader.mouse_location()
+            except Exception as ex:
+                logger.warning("mouse_location via compositor interface failed: %s", ex)
+        # Absolute mouse position is not available via evdev without compositor help
+        logger.debug("No mouse reader available, returning (0, 0)")
+        return [0, 0]
 
     def grab_devices(self):
         ### UINPUT Listener one for keyboard and eventually one for mouse

--- a/lib/autokey/wayland_compositor.py
+++ b/lib/autokey/wayland_compositor.py
@@ -1,0 +1,210 @@
+# Copyright (C) 2026 Kai (Pave Technologies)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+Wayland compositor detection and window interface factory.
+
+Under Wayland, different compositors require different approaches for
+window management (getting active window title/class, window list, etc.).
+This module detects the running compositor and provides the appropriate
+window interface.
+"""
+
+import os
+import shutil
+import subprocess
+
+logger = __import__("autokey.logger").logger.get_logger(__name__)
+
+
+# Compositor types
+COMPOSITOR_GNOME = "gnome"
+COMPOSITOR_KDE = "kde"
+COMPOSITOR_SWAY = "sway"
+COMPOSITOR_HYPRLAND = "hyprland"
+COMPOSITOR_UNKNOWN = "unknown"
+
+
+def detect_wayland_compositor():
+    """
+    Detect which Wayland compositor is running.
+
+    Uses environment variables and process checks to determine the compositor.
+    Returns one of the COMPOSITOR_* constants.
+    """
+    xdg_desktop = os.environ.get("XDG_CURRENT_DESKTOP", "").lower()
+    xdg_session_desktop = os.environ.get("XDG_SESSION_DESKTOP", "").lower()
+    desktop_session = os.environ.get("DESKTOP_SESSION", "").lower()
+
+    # Check for GNOME
+    if "gnome" in xdg_desktop or "gnome" in xdg_session_desktop:
+        logger.info("Detected GNOME Wayland compositor")
+        return COMPOSITOR_GNOME
+
+    # Check for KDE/KWin
+    if "kde" in xdg_desktop or "plasma" in xdg_desktop or "kde" in xdg_session_desktop:
+        logger.info("Detected KDE Wayland compositor")
+        return COMPOSITOR_KDE
+
+    # Check for Sway
+    if os.environ.get("SWAYSOCK"):
+        logger.info("Detected Sway Wayland compositor")
+        return COMPOSITOR_SWAY
+
+    if "sway" in xdg_desktop or "sway" in desktop_session:
+        logger.info("Detected Sway Wayland compositor")
+        return COMPOSITOR_SWAY
+
+    # Check for Hyprland
+    if os.environ.get("HYPRLAND_INSTANCE_SIGNATURE"):
+        logger.info("Detected Hyprland Wayland compositor")
+        return COMPOSITOR_HYPRLAND
+
+    if "hyprland" in xdg_desktop:
+        logger.info("Detected Hyprland Wayland compositor")
+        return COMPOSITOR_HYPRLAND
+
+    # Fallback: check running processes
+    compositor = _detect_from_processes()
+    if compositor != COMPOSITOR_UNKNOWN:
+        return compositor
+
+    logger.warning(
+        "Could not detect Wayland compositor. "
+        "XDG_CURRENT_DESKTOP=%s, XDG_SESSION_DESKTOP=%s",
+        os.environ.get("XDG_CURRENT_DESKTOP", ""),
+        os.environ.get("XDG_SESSION_DESKTOP", ""),
+    )
+    return COMPOSITOR_UNKNOWN
+
+
+def _detect_from_processes():
+    """Fallback compositor detection via running process names."""
+    try:
+        result = subprocess.run(
+            ["ps", "-eo", "comm"],
+            capture_output=True, text=True, timeout=5
+        )
+        processes = result.stdout.lower()
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return COMPOSITOR_UNKNOWN
+
+    if "gnome-shell" in processes:
+        logger.info("Detected GNOME compositor via process list")
+        return COMPOSITOR_GNOME
+    if "kwin_wayland" in processes:
+        logger.info("Detected KDE compositor via process list")
+        return COMPOSITOR_KDE
+    if "sway" in processes:
+        logger.info("Detected Sway compositor via process list")
+        return COMPOSITOR_SWAY
+    if "hyprland" in processes.split():
+        logger.info("Detected Hyprland compositor via process list")
+        return COMPOSITOR_HYPRLAND
+
+    return COMPOSITOR_UNKNOWN
+
+
+def create_wayland_window_interface(compositor=None):
+    """
+    Factory function to create the appropriate Wayland window interface.
+
+    :param compositor: Override compositor detection (for testing).
+                       If None, auto-detects.
+    :returns: An instance implementing AbstractWindowInterface.
+    :raises RuntimeError: If no suitable window interface can be created.
+    """
+    if compositor is None:
+        compositor = detect_wayland_compositor()
+
+    if compositor == COMPOSITOR_GNOME:
+        return _create_gnome_interface()
+
+    # For compositors without a dedicated interface, use the fallback
+    logger.warning(
+        "No dedicated window interface for compositor %s. "
+        "Using fallback interface with limited window detection.",
+        compositor,
+    )
+    return FallbackWindowInterface(compositor)
+
+
+def _create_gnome_interface():
+    """Attempt to create the GNOME extension window interface with error handling."""
+    try:
+        from autokey.gnome_interface import GnomeExtensionWindowInterface
+        return GnomeExtensionWindowInterface()
+    except Exception as e:
+        logger.error(
+            "Failed to connect to GNOME Shell AutoKey extension: %s. "
+            "Make sure the AutoKey GNOME extension is installed and enabled. "
+            "Falling back to limited window detection.",
+            e,
+        )
+        return FallbackWindowInterface(COMPOSITOR_GNOME)
+
+
+class FallbackWindowInterface:
+    """
+    Minimal window interface for Wayland compositors without a dedicated implementation.
+
+    Provides safe defaults so AutoKey can still function for basic hotkey/abbreviation
+    expansion, even without full window title/class detection. Window-filter-dependent
+    features will not work.
+    """
+
+    def __init__(self, compositor_name="unknown"):
+        self._compositor = compositor_name
+        self._warned = False
+        logger.info(
+            "FallbackWindowInterface active for compositor %s. "
+            "Window title/class detection is unavailable — "
+            "window filters will not work.",
+            compositor_name,
+        )
+
+    def _warn_once(self):
+        if not self._warned:
+            logger.warning(
+                "Window info requested but no compositor-specific interface is available. "
+                "Install the appropriate extension or use a supported compositor "
+                "(GNOME with AutoKey extension) for full functionality."
+            )
+            self._warned = True
+
+    def get_window_info(self, window=None, traverse=True):
+        from autokey.sys_interface.abstract_interface import WindowInfo
+        self._warn_once()
+        return WindowInfo(wm_title="", wm_class="")
+
+    def get_window_title(self, window=None, traverse=True):
+        self._warn_once()
+        return ""
+
+    def get_window_class(self, window=None, traverse=True):
+        self._warn_once()
+        return ""
+
+    def get_window_list(self):
+        self._warn_once()
+        return []
+
+    def get_screen_size(self):
+        """Return a reasonable default screen size."""
+        return [1920, 1080]
+
+    def get_active_window(self):
+        self._warn_once()
+        return None

--- a/tests/test_wayland_compositor.py
+++ b/tests/test_wayland_compositor.py
@@ -1,0 +1,144 @@
+# Copyright (C) 2026 Kai (Pave Technologies)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests for Wayland compositor detection and fallback interface."""
+
+import os
+import sys
+import pytest
+from unittest.mock import patch, MagicMock
+
+# We need to mock heavy dependencies that may not be installed in test env
+sys.modules.setdefault('dbus', MagicMock())
+sys.modules.setdefault('dbus.mainloop', MagicMock())
+sys.modules.setdefault('dbus.mainloop.glib', MagicMock())
+sys.modules.setdefault('evdev', MagicMock())
+sys.modules.setdefault('evdev.ecodes', MagicMock())
+sys.modules.setdefault('PyQt5', MagicMock())
+sys.modules.setdefault('PyQt5.QtGui', MagicMock())
+sys.modules.setdefault('PyQt5.QtWidgets', MagicMock())
+sys.modules.setdefault('PyQt5.QtCore', MagicMock())
+sys.modules.setdefault('gi', MagicMock())
+sys.modules.setdefault('gi.repository', MagicMock())
+
+from autokey.wayland_compositor import (
+    detect_wayland_compositor,
+    create_wayland_window_interface,
+    FallbackWindowInterface,
+    COMPOSITOR_GNOME,
+    COMPOSITOR_KDE,
+    COMPOSITOR_SWAY,
+    COMPOSITOR_HYPRLAND,
+    COMPOSITOR_UNKNOWN,
+)
+
+
+class TestDetectWaylandCompositor:
+    """Test compositor detection from environment variables."""
+
+    def _clean_env(self):
+        """Return env dict with detection-relevant vars cleared."""
+        return {
+            "XDG_CURRENT_DESKTOP": "",
+            "XDG_SESSION_DESKTOP": "",
+            "DESKTOP_SESSION": "",
+        }
+
+    @patch.dict(os.environ, {"XDG_CURRENT_DESKTOP": "GNOME", "XDG_SESSION_DESKTOP": ""})
+    def test_detect_gnome(self):
+        assert detect_wayland_compositor() == COMPOSITOR_GNOME
+
+    @patch.dict(os.environ, {"XDG_CURRENT_DESKTOP": "KDE", "XDG_SESSION_DESKTOP": ""})
+    def test_detect_kde(self):
+        assert detect_wayland_compositor() == COMPOSITOR_KDE
+
+    @patch.dict(os.environ, {"XDG_CURRENT_DESKTOP": "plasma", "XDG_SESSION_DESKTOP": ""})
+    def test_detect_kde_plasma(self):
+        assert detect_wayland_compositor() == COMPOSITOR_KDE
+
+    @patch.dict(os.environ, {"XDG_CURRENT_DESKTOP": "sway", "XDG_SESSION_DESKTOP": ""})
+    def test_detect_sway_from_xdg(self):
+        assert detect_wayland_compositor() == COMPOSITOR_SWAY
+
+    @patch.dict(os.environ, {"XDG_CURRENT_DESKTOP": "Hyprland", "XDG_SESSION_DESKTOP": ""})
+    def test_detect_hyprland_from_xdg(self):
+        assert detect_wayland_compositor() == COMPOSITOR_HYPRLAND
+
+    @patch("autokey.wayland_compositor._detect_from_processes", return_value=COMPOSITOR_UNKNOWN)
+    def test_detect_unknown(self, mock_proc):
+        env = self._clean_env()
+        env.pop("SWAYSOCK", None)
+        env.pop("HYPRLAND_INSTANCE_SIGNATURE", None)
+        with patch.dict(os.environ, env, clear=False):
+            # Ensure socket-based vars are gone
+            os.environ.pop("SWAYSOCK", None)
+            os.environ.pop("HYPRLAND_INSTANCE_SIGNATURE", None)
+            assert detect_wayland_compositor() == COMPOSITOR_UNKNOWN
+
+
+class TestFallbackWindowInterface:
+    """Test the fallback window interface returns safe defaults."""
+
+    def setup_method(self):
+        self.iface = FallbackWindowInterface("test-compositor")
+
+    def test_get_window_info_returns_namedtuple(self):
+        info = self.iface.get_window_info()
+        assert info.wm_title == ""
+        assert info.wm_class == ""
+
+    def test_get_window_title_returns_empty(self):
+        assert self.iface.get_window_title() == ""
+
+    def test_get_window_class_returns_empty(self):
+        assert self.iface.get_window_class() == ""
+
+    def test_get_window_list_returns_empty(self):
+        assert self.iface.get_window_list() == []
+
+    def test_get_screen_size_returns_default(self):
+        size = self.iface.get_screen_size()
+        assert len(size) == 2
+        assert size[0] > 0 and size[1] > 0
+
+    def test_get_active_window_returns_none(self):
+        assert self.iface.get_active_window() is None
+
+
+class TestCreateWaylandWindowInterface:
+    """Test the factory function."""
+
+    def test_unknown_compositor_returns_fallback(self):
+        iface = create_wayland_window_interface(compositor=COMPOSITOR_UNKNOWN)
+        assert isinstance(iface, FallbackWindowInterface)
+
+    def test_kde_returns_fallback(self):
+        iface = create_wayland_window_interface(compositor=COMPOSITOR_KDE)
+        assert isinstance(iface, FallbackWindowInterface)
+
+    def test_sway_returns_fallback(self):
+        iface = create_wayland_window_interface(compositor=COMPOSITOR_SWAY)
+        assert isinstance(iface, FallbackWindowInterface)
+
+    @patch("autokey.wayland_compositor._create_gnome_interface")
+    def test_gnome_attempts_gnome_interface(self, mock_create):
+        mock_create.return_value = MagicMock()
+        create_wayland_window_interface(compositor=COMPOSITOR_GNOME)
+        mock_create.assert_called_once()
+
+    def test_gnome_falls_back_on_dbus_failure(self):
+        # Without a running GNOME Shell, should fall back gracefully
+        iface = create_wayland_window_interface(compositor=COMPOSITOR_GNOME)
+        assert isinstance(iface, FallbackWindowInterface) or hasattr(iface, 'get_window_info')


### PR DESCRIPTION
## Summary

This PR improves Wayland support by making AutoKey compositor-aware instead of hardcoding GNOME:

- **Compositor detection**: Auto-detects GNOME, KDE, Sway, and Hyprland via `XDG_CURRENT_DESKTOP`, compositor-specific env vars (`SWAYSOCK`, `HYPRLAND_INSTANCE_SIGNATURE`), and process inspection fallback.
- **Graceful fallback**: Introduces `FallbackWindowInterface` with safe defaults for unsupported compositors. Basic hotkey/abbreviation expansion works even without window title/class detection.
- **Decoupled UInput from GNOME**: `UInputInterface` no longer inherits from `GnomeMouseReadInterface`. Mouse position reading is injected via `set_mouse_reader()`, so uinput works independently of the GNOME extension.
- **NoneType crash fixes**: `gnome_interface.py` now handles `_active_window()` returning `None` (no focused window). `service.py` now handles `window_info` being `None`.
- **Bug fix**: Added missing `@abstractmethod` decorator on `release_key` in `AbstractSysInterface`.

## Motivation

Issue #87 — AutoKey crashes on non-GNOME Wayland compositors because the develop branch hardcodes `GnomeExtensionWindowInterface` as the only Wayland window interface. Users on KDE Plasma, Sway, Hyprland, etc. cannot use AutoKey at all. This PR provides the architectural foundation for multi-compositor support while keeping GNOME as the fully-featured path.

## Files Changed

| File | Change |
|------|--------|
| `lib/autokey/wayland_compositor.py` | **New** — Compositor detection + factory + fallback interface |
| `lib/autokey/iomediator/iomediator.py` | Use factory instead of hardcoded GNOME interface |
| `lib/autokey/uinput_interface.py` | Remove GNOME inheritance, add `set_mouse_reader()` |
| `lib/autokey/gnome_interface.py` | Handle `None` from `_active_window()` |
| `lib/autokey/service.py` | Handle `None` window_info |
| `lib/autokey/sys_interface/abstract_interface.py` | Add missing `@abstractmethod` |
| `tests/test_wayland_compositor.py` | **New** — 17 tests covering detection, fallback, and factory |

## Test Plan

- [x] All 17 new unit tests pass
- [ ] Verify GNOME/Wayland still works with the AutoKey GNOME extension
- [ ] Verify AutoKey starts without crash on KDE/Wayland (with fallback)
- [ ] Verify X11 path is unaffected

Addresses #87
