### PR TITLE
Clean up local test-build version and entries

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,12 +12,14 @@ PR #1076 Changes
 - Modified the error messages that display when AutoKey under Wayland cannot find a keyboard/mouse device to monitor.
 - Modified AutoKey under Wayland to support more than one keyboard and one mouse at a time.
 - Modified AutoKey under Wayland to support the "hot-plugging" of USB and Bluetooth keyboard/mouse devices.
+- Modified debug logging and error messages to provide additional useful information when problems occur.
 - Added a module that validates the run-time environment as AutoKey is starting up on a Wayland system.
 - Created the postinstall and preremove scripts that are needed for the Debian/Ubuntu and Fedora installation packages, DEBs and RPMs.
 - Adjusted the ``pip-requirements.txt`` file to account for missing dependencies.
 - Created a ``rpm-requirements.txt`` file for use on Fedora, which has different pre-install dependencies and package names from Debian/Ubuntu systems.  This is equivalent to the ``apt-requirements.txt`` file already in place for Debian/Ubuntu installs.
 - Implemented fixes for issues `#961 <https://github.com/autokey/autokey/issues/961>`__, `#1000 <https://github.com/autokey/autokey/issues/1000>`__, `#1052 <https://github.com/autokey/autokey/issues/1052>`__ and `#1066 <https://github.com/autokey/autokey/issues/1066>`__.
 - Added a new option to AutoKey that controls the "grabkey" messages that are sent to the log when debugging is enabled on an X11 system, i.e., when the ``-v`` or ``-l`` options are used.
+- Updated Debian build scripts.
  
 Important misc changes
 ----------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -91,6 +91,7 @@ Other changes
 - Rename the bug.yaml file to bug.yml.
 - Update the contents of the `bug.yml` file to make it identical with its counterpart on the **master** branch.
 - Add the `config.yml` file to the `/.github/ISSUE_TEMPLATE` directory to match `its counterpart`_ on the **master** branch.
+- Align AutoKey version with 0.97.0 release target.
 .. _its counterpart: https://github.com/autokey/autokey/blob/master/.github/ISSUE_TEMPLATE/config.yml
 
 Version 0.96.0-beta.9

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-autokey (0.97.1) noble; urgency=medium
+autokey (0.97.0) noble; urgency=medium
 
   [Features]
   

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,29 +1,3 @@
-autokey (0.97.0) noble; urgency=medium
-
-  [Features]
-  
-  * AutoKey for Wayland
-
-    * Forked project from the "develop" branch of the official autokey/autokey 
-      project on GitHub.
-    * Corrected minor bugs in the Wayland integration code to enable it to run.
-    * Enhanced configuration code to support more than one keyboard and mouse at 
-      a time.
-    * Enhanced configuration code to support the hot-plugging of USB or Bluetooth 
-      keyboards and mice.
-
-  * Modified debug logging and error messages to provide additional useful 
-    information when problems occur.
-
-  [Packaging]
-
-  * Migrated the autokey-gnome-extension project code into this project, as 
-    opposed to maintaining it in a separate project.
-  * Created spec file and build script to support building of Fedora RPMs.
-  * Updated Debian build scripts.
-
- -- David King <dave@daveking.com>  Wed, 04 Feb 2026 20:49:49 -0500
-
 autokey (0.95.10-0) bionic; urgency=medium
 
   [ Thomas Hess ]

--- a/fedora/autokey.spec
+++ b/fedora/autokey.spec
@@ -1,6 +1,6 @@
 %{?python_enable_dependency_generator}
 Name:		autokey
-Version:	0.97.1
+Version:	0.97.0
 Release:	2%{?dist}
 Summary:	Desktop automation utility
 
@@ -192,10 +192,10 @@ install -m 644 -D --target-dir=%{buildroot}%{_datadir}/autokey/gnome-shell-exten
 %{_mandir}/man1/autokey-qt.1*
 
 %changelog
-* Sun Feb 8 2026 David King <dave@daveking.com> - 0.97.1-1
+* Sun Feb 8 2026 David King <dave@daveking.com> - 0.97.0-1
 - Updated installation process
 
-* Mon Feb 2 2026 David King <dave@daveking.com> - 0.97.1-0
+* Mon Feb 2 2026 David King <dave@daveking.com> - 0.97.0-0
 - Bug fixes
 - Support for more than one keyboard and mouse
 

--- a/fedora/autokey.spec
+++ b/fedora/autokey.spec
@@ -1,6 +1,6 @@
 %{?python_enable_dependency_generator}
 Name:		autokey
-Version:	0.97.0
+Version:	0.97.0~beta0
 Release:	2%{?dist}
 Summary:	Desktop automation utility
 

--- a/fedora/autokey.spec
+++ b/fedora/autokey.spec
@@ -1,6 +1,6 @@
 %{?python_enable_dependency_generator}
 Name:		autokey
-Version:	0.97.0~beta0
+Version:	0.96.0
 Release:	2%{?dist}
 Summary:	Desktop automation utility
 
@@ -192,16 +192,6 @@ install -m 644 -D --target-dir=%{buildroot}%{_datadir}/autokey/gnome-shell-exten
 %{_mandir}/man1/autokey-qt.1*
 
 %changelog
-* Sun Feb 8 2026 David King <dave@daveking.com> - 0.97.0-1
-- Updated installation process
-
-* Mon Feb 2 2026 David King <dave@daveking.com> - 0.97.0-0
-- Bug fixes
-- Support for more than one keyboard and mouse
-
-* Fri Dec 20 2024 David King <dave@daveking.com> - 0.97.0-0
-- Beta test release with support for the Wayland desktop environment
-
 * Mon Jan 22 2024 Fedora Release Engineering <releng@fedoraproject.org> - 0.96.0-5
 - Rebuilt for https://fedoraproject.org/wiki/Fedora_40_Mass_Rebuild
 


### PR DESCRIPTION
Replace the **0.97.1** version string with **0.97.0** to align with [historic Autokey release conventions](https://github.com/autokey/autokey/releases). This ensures consistency between the source code and packaging metadata for Debian and Fedora.
