### PR TITLE
Use raw triple-quotes to protect escape-sequences

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -91,6 +91,7 @@ Other changes
 - Rename the bug.yaml file to bug.yml.
 - Update the contents of the `bug.yml` file to make it identical with its counterpart on the **master** branch.
 - Add the `config.yml` file to the `/.github/ISSUE_TEMPLATE` directory to match `its counterpart`_ on the **master** branch.
+- Use raw-string format in `window.py` to handle invalid escape sequences.
 .. _its counterpart: https://github.com/autokey/autokey/blob/master/.github/ISSUE_TEMPLATE/config.yml
 
 Version 0.96.0-beta.9

--- a/lib/autokey/scripting/window.py
+++ b/lib/autokey/scripting/window.py
@@ -31,7 +31,7 @@ XRANDR_MONITOR_REGEX = r" (\d{3,4}).*?x(\d{3,4})\/.*?\+(\d{1,4})\+(\d{1,4})"
 # this translates to monitor x and y size, and x and y offset for each monitor
 
 class Window:
-    """
+    r"""
     Basic window management using wmctrl
 
     Note: in all cases where a window title is required (with the exception of wait_for_focus()),


### PR DESCRIPTION
Replace the triple-quote in line 34 of the `window.py` file with a raw triple-quote to prevent the **SyntaxWarning** about invalid escape-sequences that gets triggered by the escapes in lines 40 and 41 of the same file when tests are run under **Python 3.12**. This will also future-proof AutoKey, because the current **SyntaxWarning** is scheduled to [eventually become a **SyntaxError** in a future Python version](https://docs.python.org/3/whatsnew/3.12.html).