### PR TITLE
Bump GitHub Action and Python versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,18 +16,18 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.12.9]
+        python-version: [3.14]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
 
     - name: Cache pip
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         # This path is specific to Ubuntu
         path: ~/.cache/pip
@@ -53,7 +53,7 @@ jobs:
         mv ../*.deb debs
 
     - name: Upload built debs as artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: debs
         path: debs
@@ -64,16 +64,16 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.12.9]
+        python-version: [3.14]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
 
     - name: Cache pip
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         # This path is specific to Ubuntu
         path: ~/.cache/pip
@@ -99,7 +99,7 @@ jobs:
         --outdir dist/
 
     - name: Upload built dist as artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: dist
         path: dist/
@@ -110,30 +110,30 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.12.9]
+        python-version: [3.14]
     needs: [build_pypi_wheel, build_deb]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         # Fetch all history so that we get tags.
         fetch-depth: 0
 
       # Waits for checks to complete before releasing.
     - name: Wait on tests
-      uses: lewagon/wait-on-check-action@master
+      uses: lewagon/wait-on-check-action@v1.6.1
       with:
         ref: ${{ github.ref }}
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         wait-interval: 10
-        check-name: 'pytest (3.12.9)'
+        check-name: 'pytest (3.14)'
 
     - name: Download built dist as artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: dist
         path: dist/
     - name: Download built debs as artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: debs
         path: ../debs

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: doc/scripting
   deploy:
@@ -29,5 +29,5 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
           

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -21,17 +21,17 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "${{ matrix.python-version }}"
 
       - name: Cache pip
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           # This path is specific to Ubuntu
           path: ~/.cache/pip
@@ -83,19 +83,19 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "${{ matrix.python-version }}"
 
       - name: Cache pip
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           # This path is specific to Ubuntu
           path: ~/.cache/pip
@@ -117,7 +117,7 @@ jobs:
         run: tox -e clean,coverage,report
 
       - name: Upload pytest test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pytest-results-${{ matrix.python-version }}
           path: junit/test-results-${{ matrix.python-version }}.xml
@@ -128,7 +128,7 @@ jobs:
         run: tar -cvzf test_coverage_report-${{ matrix.python-version }}.tar.gz test_coverage_report_html/
 
       - name: Upload test coverage report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test_coverage_report-${{ matrix.python-version }}.tar.gz
           path: test_coverage_report-${{ matrix.python-version }}.tar.gz
@@ -142,12 +142,12 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "${{ matrix.python-version }}"
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -91,11 +91,9 @@ Other changes
 - Rename the bug.yaml file to bug.yml.
 - Update the contents of the `bug.yml` file to make it identical with its counterpart on the **master** branch.
 - Add the `config.yml` file to the `/.github/ISSUE_TEMPLATE` directory to match `its counterpart`_ on the **master** branch.
-<<<<<<< update-bump-workflow-versions
-- Bump GitHub Action and Python versions.
-=======
 - Use raw-string format in `window.py` to handle invalid escape sequences.
->>>>>>> develop
+- Bump GitHub Action and Python versions.
+
 .. _its counterpart: https://github.com/autokey/autokey/blob/master/.github/ISSUE_TEMPLATE/config.yml
 
 Version 0.96.0-beta.9

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -91,6 +91,7 @@ Other changes
 - Rename the bug.yaml file to bug.yml.
 - Update the contents of the `bug.yml` file to make it identical with its counterpart on the **master** branch.
 - Add the `config.yml` file to the `/.github/ISSUE_TEMPLATE` directory to match `its counterpart`_ on the **master** branch.
+- Bump GitHub Action and Python versions.
 .. _its counterpart: https://github.com/autokey/autokey/blob/master/.github/ISSUE_TEMPLATE/config.yml
 
 Version 0.96.0-beta.9

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ addopts =
 
 
 [tox:tox]
-; envlist = py38,py39,py310,py311,py312
+; envlist = py310,py311,py312,py313,py314
 ; Only run test environment by default, so just running `tox` is fast
 ; and doesn't include the overhead of coverage or any other build
 ; pathways.

--- a/setup.py
+++ b/setup.py
@@ -33,8 +33,8 @@ except ImportError:
 else:
     import setuptools.command.build_py
 
-if sys.version_info < (3, 9, 0):
-    print("Autokey requires Python 3.9.0 or later. You are using " + ".".join(map(str, sys.version_info[:3])))
+if sys.version_info < (3, 10, 20):
+    print("Autokey requires Python 3.10.20 or later. You are using " + ".".join(map(str, sys.version_info[:3])))
     sys.exit(1)
 
 
@@ -137,7 +137,7 @@ setup(
     # If using this, would have to also set common.VERSION from this so that
     # the autokey 'about' menu shows the correct version.
     # use_scm_version=True,
-    python_requires=">=3.9",
+    python_requires=">=3.10",
     # This requires autokey submodules (subdirectories) to contain their own `__init__.py` file (i.e.
     # they advertise themselves as modules).
     # find_namespace_packages might be a better alternative that doesn't
@@ -216,7 +216,7 @@ setup(
         'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
         'Natural Language :: English',
         'Operating System :: POSIX :: Linux',
-        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
     ],
     keywords='automation hotkey expansion expander phrase macros keyboard auto key autokey ak shortcuts bind autohotkey mouse customization',
 )


### PR DESCRIPTION
Bump action and Python versions in the workflow files using [these steps](https://gist.github.com/Elliria/2dc56b4b0316d71819666d7bf43b726a) that provide links to the references I used.

Special attention was given to these two points:
* Use 2-segment versions to prevent version patches from causing test-failures, with the exception of the **sys.version_info** version in the `setup.py` file, which should be 3 segments since it makes sense in the context of its use there and won't be impacted by version patches or updates.
* Use hard-coded version instead of **master** for the **lewagon/wait-on-check-action** in the `build.yml` file to prevent updates from causing test-failures.