### PR TITLE
Update pyhamcrest dependency version to 2.1.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ deps =
     pytest
     pytest-cov
     pytest-xvfb
-    pyhamcrest>=1.8.1
+    pyhamcrest>=2.1.0
     PyQt5
     dbus-python
     PyGObject


### PR DESCRIPTION
* See [the PyHamcrest PyPI page](https://pypi.org/project/PyHamcrest) to verify that **2.1.0** is the current version.
