### PR TITLE
Update setup.cfg white-space

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -93,6 +93,7 @@ Other changes
 - Add the `config.yml` file to the `/.github/ISSUE_TEMPLATE` directory to match `its counterpart`_ on the **master** branch.
 - Use raw-string format in `window.py` to handle invalid escape sequences.
 - Bump GitHub Action and Python versions.
+- Update white-space in `setup.cfg` for readability and consistency with other lines.
 
 .. _its counterpart: https://github.com/autokey/autokey/blob/master/.github/ISSUE_TEMPLATE/config.yml
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,14 +1,14 @@
 [bdist_wheel]
 universal = 0
 [aliases]
-test=pytest
+test = pytest
 
 
 [tool:pytest]
-log_cli_level=debug
+log_cli_level = debug
 testpaths =
   tests
-norecursedirs=dist build .tox scripts
+norecursedirs = dist build .tox scripts
 addopts =
 #   --cov-report=xml
 ; --cov-report=term-missing
@@ -35,7 +35,7 @@ deps =
     pytest
     pytest-cov
     pytest-xvfb
-    pyhamcrest>=2.1.0
+    pyhamcrest >= 2.1.0
     PyQt5
     dbus-python
     PyGObject


### PR DESCRIPTION
* Add white-space around some delimiters for readability and consistency with the other delimiters in the file.
* Note that the **cov** lines in the **[tool:pytest]** section are an exception to this and cannot contain white-space since they're command-line options and white-space could lead to unexpected behavior.
