### PR TITLE
Port Qt UI from PyQt5 to qtpy (PyQt5/PyQt6 compatible)

### DIFF
--- a/debian/build_requirements.txt
+++ b/debian/build_requirements.txt
@@ -5,6 +5,7 @@ python3-all
 gir1.2-gtk-3.0
 python3-pyqt5.qsci
 python3-pyqt5.qtsvg
+python3-qtpy
 python3-xlib
 devscripts
 python3-pip

--- a/debian/control
+++ b/debian/control
@@ -11,6 +11,7 @@ Build-Depends: debhelper-compat (= 12),
                python3-gi,
                python3-pyqt5.qsci,
                python3-pyqt5.qtsvg,
+               python3-qtpy,
                python3-setuptools,
                python3-xlib,
                python3-pyinotify

--- a/lib/autokey/UI_common_functions.py
+++ b/lib/autokey/UI_common_functions.py
@@ -22,8 +22,8 @@ common_modules = ['argparse', 'collections', 'enum', 'faulthandler',
             'warnings', 'webbrowser', 'dbus', 'pyinotify']
 gtk_modules = ['gi', 'gi.repository.Gtk', 'gi.repository.Gdk', 'gi.repository.Pango',
             'gi.repository.Gio', 'gi.repository.GtkSource']
-qt_modules = ['PyQt5', 'PyQt5.QtGui', 'PyQt5.QtWidgets', 'PyQt5.QtCore',
-            'PyQt5.Qsci']
+qt_modules = ['qtpy', 'qtpy.QtGui', 'qtpy.QtWidgets', 'qtpy.QtCore',
+            'qtpy.Qsci']
 
 # wmctrl, xrandr are x11 specific programs.
 x11_programs = ['wmctrl', 'xrandr']

--- a/lib/autokey/macro.py
+++ b/lib/autokey/macro.py
@@ -12,7 +12,7 @@ import gettext
 gettext.install("autokey")
 
 if common.USED_UI_TYPE == "QT":
-    from PyQt5.QtWidgets import QAction
+    from qtpy.QtWidgets import QAction
 
     def _(text: str, args: tuple=None):
         """localisation function, currently returns the identity. If args are given, those are used to format

--- a/lib/autokey/qtapp.py
+++ b/lib/autokey/qtapp.py
@@ -21,9 +21,9 @@ import sys
 import os.path
 import queue
 
-from PyQt5.QtCore import QObject, QEvent, Qt, pyqtSignal
-from PyQt5.QtGui import QCursor, QIcon
-from PyQt5.QtWidgets import QMessageBox, QApplication
+from qtpy.QtCore import QObject, QEvent, Qt, Signal as pyqtSignal
+from qtpy.QtGui import QCursor, QIcon
+from qtpy.QtWidgets import QMessageBox, QApplication
 
 import autokey.model.script
 from autokey import common
@@ -70,7 +70,7 @@ class Application(AutokeyUIInterface, QApplication, AutokeyApplication, metaclas
             self.show_error_dialog("Fatal error starting AutoKey.", str(e))
             sys.exit(1)
         else:
-            sys.exit(self.exec_())
+            sys.exit(self.exec())
 
     def initialise(self):
         self.setWindowIcon(QIcon.fromTheme(common.ICON_FILE, qtui_common.load_icon(qtui_common.AutoKeyIcon.AUTOKEY)))
@@ -157,7 +157,7 @@ class Application(AutokeyUIInterface, QApplication, AutokeyApplication, metaclas
         )
         if details:
             message_box.setDetailedText(details)
-        message_box.exec_()
+        message_box.exec()
 
     def show_popup_menu(self, folders: list=None, items: list=None, onDesktop=True, title=None):
         if items is None:

--- a/lib/autokey/qtui/__main__.py
+++ b/lib/autokey/qtui/__main__.py
@@ -19,10 +19,13 @@ import faulthandler
 
 faulthandler.enable()
 
-from PyQt5 import QtCore
+from qtpy import QtCore
 from autokey.qtapp import Application
 
-QtCore.QCoreApplication.setAttribute(QtCore.Qt.AA_X11InitThreads)
+try:
+    QtCore.QCoreApplication.setAttribute(QtCore.Qt.AA_X11InitThreads)
+except AttributeError:
+    pass  # Qt6: AA_X11InitThreads was removed; threading is always initialized
 
 # remove WINDOWID environment variable so that zenity is not tied to the window from which it was launched.
 try:

--- a/lib/autokey/qtui/autokey_treewidget.py
+++ b/lib/autokey/qtui/autokey_treewidget.py
@@ -16,9 +16,9 @@
 
 from typing import Union, List, Optional
 
-from PyQt5.QtCore import Qt, QEvent, QModelIndex
-from PyQt5.QtGui import QKeySequence, QIcon, QKeyEvent, QMouseEvent, QDragMoveEvent, QDropEvent
-from PyQt5.QtWidgets import QTreeWidget, QTreeWidgetItem, QAbstractItemView
+from qtpy.QtCore import Qt, QEvent, QModelIndex
+from qtpy.QtGui import QKeySequence, QIcon, QKeyEvent, QMouseEvent, QDragMoveEvent, QDropEvent
+from qtpy.QtWidgets import QTreeWidget, QTreeWidgetItem, QAbstractItemView
 
 import autokey.model.folder
 import autokey.model.phrase

--- a/lib/autokey/qtui/centralwidget.py
+++ b/lib/autokey/qtui/centralwidget.py
@@ -18,10 +18,10 @@ import logging
 import pathlib
 import typing
 
-from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QIcon, QCursor, QBrush
-from PyQt5.QtWidgets import QHeaderView, QMessageBox, QFileDialog, QAction, QWidget, QMenu
-from PyQt5.QtWidgets import QListWidget, QListWidgetItem
+from qtpy.QtCore import Qt
+from qtpy.QtGui import QIcon, QCursor, QBrush
+from qtpy.QtWidgets import QHeaderView, QMessageBox, QFileDialog, QAction, QWidget, QMenu
+from qtpy.QtWidgets import QListWidget, QListWidgetItem
 
 import autokey.model.folder
 import autokey.model.helpers
@@ -191,7 +191,7 @@ class CentralWidget(*ui_common.inherits_from_ui_file_with_name("centralwidget"))
 
         )
         message_box.button(QMessageBox.No).setText("Create elsewhere")  # TODO: i18n
-        result = message_box.exec_()
+        result = message_box.exec()
 
         self.window().app.monitor.suspend()
 

--- a/lib/autokey/qtui/common.py
+++ b/lib/autokey/qtui/common.py
@@ -19,11 +19,11 @@ import pathlib
 import enum
 import functools
 
-from PyQt5.QtCore import QFile, QSize
-from PyQt5.QtGui import QFont, QIcon, QPixmap, QPainter, QColor, QFontDatabase
-from PyQt5.QtWidgets import QMessageBox, QLabel
-from PyQt5 import uic
-from PyQt5.QtSvg import QSvgRenderer
+from qtpy.QtCore import QFile, QSize
+from qtpy.QtGui import QFont, QIcon, QPixmap, QPainter, QColor, QFontDatabase
+from qtpy.QtWidgets import QMessageBox, QLabel
+from qtpy import uic
+from qtpy.QtSvg import QSvgRenderer
 
 import autokey.configmanager.configmanager_constants as cm_constants
 from autokey.logger import get_logger

--- a/lib/autokey/qtui/configwindow.py
+++ b/lib/autokey/qtui/configwindow.py
@@ -16,9 +16,9 @@
 
 import webbrowser
 
-from PyQt5.QtCore import pyqtSignal, QTimer
-from PyQt5.QtGui import QIcon, QKeySequence, QCloseEvent
-from PyQt5.QtWidgets import QApplication, QAction, QMenu
+from qtpy.QtCore import Signal as pyqtSignal, QTimer
+from qtpy.QtGui import QIcon, QKeySequence, QCloseEvent
+from qtpy.QtWidgets import QApplication, QAction, QMenu
 
 
 import autokey.common

--- a/lib/autokey/qtui/dbus_service.py
+++ b/lib/autokey/qtui/dbus_service.py
@@ -13,8 +13,13 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from PyQt5.QtCore import Q_CLASSINFO, pyqtSlot
-from PyQt5.QtDBus import QDBusAbstractAdaptor, QDBusConnection
+from qtpy.QtCore import Slot as pyqtSlot
+from qtpy.QtDBus import QDBusAbstractAdaptor, QDBusConnection
+
+try:
+    from qtpy.QtCore import Q_CLASSINFO
+except ImportError:
+    from PyQt6.QtCore import pyqtClassInfo as Q_CLASSINFO
 
 
 class AppService(QDBusAbstractAdaptor):

--- a/lib/autokey/qtui/dialogs/abbrsettings.py
+++ b/lib/autokey/qtui/dialogs/abbrsettings.py
@@ -19,8 +19,8 @@ This module contains the abbreviation settings dialog and used components.
 This dialog allows the user to set and configure abbreviations to trigger scripts and phrases.
 """
 
-from PyQt5 import QtCore
-from PyQt5.QtWidgets import QListWidgetItem, QDialogButtonBox
+from qtpy import QtCore
+from qtpy.QtWidgets import QListWidgetItem, QDialogButtonBox
 
 import autokey.model.folder
 import autokey.model.helpers

--- a/lib/autokey/qtui/dialogs/about_autokey_dialog.py
+++ b/lib/autokey/qtui/dialogs/about_autokey_dialog.py
@@ -14,8 +14,8 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 import sys
 
-from PyQt5.QtWidgets import QWidget
-from PyQt5.QtCore import QSize
+from qtpy.QtWidgets import QWidget
+from qtpy.QtCore import QSize
 
 import autokey.common
 from autokey.qtui import common as ui_common

--- a/lib/autokey/qtui/dialogs/detectdialog.py
+++ b/lib/autokey/qtui/dialogs/detectdialog.py
@@ -15,7 +15,7 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 from typing import Tuple
 
-from PyQt5.QtWidgets import QWidget
+from qtpy.QtWidgets import QWidget
 
 from autokey.qtui import common as ui_common
 

--- a/lib/autokey/qtui/dialogs/hotkeysettings.py
+++ b/lib/autokey/qtui/dialogs/hotkeysettings.py
@@ -16,8 +16,8 @@
 
 import typing
 
-from PyQt5.QtCore import pyqtSignal
-from PyQt5.QtWidgets import QDialogButtonBox
+from qtpy.QtCore import Signal as pyqtSignal
+from qtpy.QtWidgets import QDialogButtonBox
 
 import autokey.model.folder
 import autokey.model.helpers

--- a/lib/autokey/qtui/dialogs/show_recent_script_errors.py
+++ b/lib/autokey/qtui/dialogs/show_recent_script_errors.py
@@ -15,8 +15,8 @@
 
 import typing
 
-from PyQt5.QtWidgets import QApplication, QAbstractButton, QDialogButtonBox
-from PyQt5.QtCore import pyqtSlot, pyqtSignal
+from qtpy.QtWidgets import QApplication, QAbstractButton, QDialogButtonBox
+from qtpy.QtCore import Slot as pyqtSlot, Signal as pyqtSignal
 
 from autokey.model.script import ScriptErrorRecord
 

--- a/lib/autokey/qtui/dialogs/windowfiltersettings.py
+++ b/lib/autokey/qtui/dialogs/windowfiltersettings.py
@@ -16,7 +16,7 @@
 
 import re
 
-from PyQt5.QtWidgets import QDialog
+from qtpy.QtWidgets import QDialog
 
 import autokey.iomediator.windowgrabber
 import autokey.model.folder
@@ -74,7 +74,7 @@ class WindowFilterSettingsDialog(*qtui_common.inherits_from_ui_file_with_name("w
     def _receiveWindowInfo(self, info):
         dlg = DetectDialog(self)
         dlg.populate(info)
-        dlg.exec_()
+        dlg.exec()
 
         if dlg.result() == QDialog.Accepted:
             self.trigger_regex_line_edit.setText(dlg.get_choice())

--- a/lib/autokey/qtui/folderpage.py
+++ b/lib/autokey/qtui/folderpage.py
@@ -15,7 +15,7 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 import subprocess
 
-from PyQt5.QtWidgets import QMessageBox
+from qtpy.QtWidgets import QMessageBox
 
 import autokey.configmanager.configmanager_constants as cm_constants
 import autokey.qtui.common as ui_common

--- a/lib/autokey/qtui/notifier.py
+++ b/lib/autokey/qtui/notifier.py
@@ -16,8 +16,8 @@
 
 from typing import Optional, Callable, TYPE_CHECKING
 
-from PyQt5.QtGui import QIcon
-from PyQt5.QtWidgets import QSystemTrayIcon, QAction, QMenu
+from qtpy.QtGui import QIcon
+from qtpy.QtWidgets import QSystemTrayIcon, QAction, QMenu
 
 from autokey.qtui import popupmenu
 import autokey.qtui.common as ui_common

--- a/lib/autokey/qtui/phrasepage.py
+++ b/lib/autokey/qtui/phrasepage.py
@@ -16,7 +16,7 @@
 
 import subprocess
 
-from PyQt5.QtWidgets import QMessageBox
+from qtpy.QtWidgets import QMessageBox
 
 import autokey.model.phrase
 from autokey.qtui import common as ui_common

--- a/lib/autokey/qtui/popupmenu.py
+++ b/lib/autokey/qtui/popupmenu.py
@@ -16,9 +16,9 @@
 
 from typing import List, Union
 
-from PyQt5.QtCore import Qt, pyqtSignal
-from PyQt5.QtGui import QIcon
-from PyQt5.QtWidgets import QMenu, QAction, QWidget
+from qtpy.QtCore import Qt, Signal as pyqtSignal
+from qtpy.QtGui import QIcon
+from qtpy.QtWidgets import QMenu, QAction, QWidget
 
 
 import autokey.configmanager.configmanager as cm

--- a/lib/autokey/qtui/scriptpage.py
+++ b/lib/autokey/qtui/scriptpage.py
@@ -17,8 +17,8 @@
 import os.path
 import subprocess
 
-from PyQt5 import Qsci
-from PyQt5.QtWidgets import QMessageBox
+from qtpy import Qsci
+from qtpy.QtWidgets import QMessageBox
 
 import autokey.model.script
 from autokey.qtui import common as ui_common

--- a/lib/autokey/qtui/settings/engine.py
+++ b/lib/autokey/qtui/settings/engine.py
@@ -16,8 +16,8 @@
 
 import sys
 
-from PyQt5.QtCore import pyqtSlot
-from PyQt5.QtWidgets import QFileDialog, QWidget, QApplication
+from qtpy.QtCore import Slot as pyqtSlot
+from qtpy.QtWidgets import QFileDialog, QWidget, QApplication
 
 from autokey.qtui import common
 logger = __import__("autokey.logger").logger.get_logger(__name__)

--- a/lib/autokey/qtui/settings/general.py
+++ b/lib/autokey/qtui/settings/general.py
@@ -15,8 +15,8 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 
-from PyQt5.QtCore import Qt
-from PyQt5.QtWidgets import QWidget, QComboBox
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import QWidget, QComboBox
 
 
 import autokey.configmanager.autostart

--- a/lib/autokey/qtui/settings/settingsdialog.py
+++ b/lib/autokey/qtui/settings/settingsdialog.py
@@ -15,8 +15,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 from typing import TYPE_CHECKING
 
-from PyQt5.QtCore import pyqtSlot
-from PyQt5.QtWidgets import QApplication, QWidget
+from qtpy.QtCore import Slot as pyqtSlot
+from qtpy.QtWidgets import QApplication, QWidget
 
 from autokey.qtui import common
 

--- a/lib/autokey/qtui/settings/specialhotkeys.py
+++ b/lib/autokey/qtui/settings/specialhotkeys.py
@@ -16,7 +16,7 @@
 
 import typing
 
-from PyQt5.QtWidgets import QDialog, QWidget, QApplication, QLabel, QPushButton
+from qtpy.QtWidgets import QDialog, QWidget, QApplication, QLabel, QPushButton
 
 from autokey.qtui.dialogs import GlobalHotkeyDialog
 import autokey.qtui.common as ui_common
@@ -88,7 +88,7 @@ class SpecialHotkeySettings(*ui_common.inherits_from_ui_file_with_name("specialh
     # ---- Signal handlers
 
     def on_set_config_button_pressed(self):
-        self.show_config_dlg.exec_()
+        self.show_config_dlg.exec()
 
         if self.show_config_dlg.result() == QDialog.Accepted:
             self.use_config_hotkey = True
@@ -104,7 +104,7 @@ class SpecialHotkeySettings(*ui_common.inherits_from_ui_file_with_name("specialh
         self.show_config_dlg.reset()
 
     def on_set_monitor_button_pressed(self):
-        self.toggle_monitor_dlg.exec_()
+        self.toggle_monitor_dlg.exec()
 
         if self.toggle_monitor_dlg.result() == QDialog.Accepted:
             self.use_service_hotkey = True

--- a/lib/autokey/qtui/settingswidget.py
+++ b/lib/autokey/qtui/settingswidget.py
@@ -15,7 +15,7 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 
-from PyQt5.QtWidgets import QDialog
+from qtpy.QtWidgets import QDialog
 
 import autokey.model.helpers
 from autokey.model.triggermode import TriggerMode
@@ -170,7 +170,7 @@ class SettingsWidget(*inherits_from_ui_file_with_name("settingswidget")):
     # ---- Signal handlers
 
     def on_set_abbreviation_button_pressed(self):
-        self.abbr_settings_dialog.exec_()
+        self.abbr_settings_dialog.exec()
 
         if self.abbr_settings_dialog.result() == QDialog.Accepted:
             self.set_dirty()
@@ -186,7 +186,7 @@ class SettingsWidget(*inherits_from_ui_file_with_name("settingswidget")):
         self.abbr_settings_dialog.reset()
 
     def on_set_hotkey_button_pressed(self):
-        self.hotkey_settings_dialog.exec_()
+        self.hotkey_settings_dialog.exec()
 
         if self.hotkey_settings_dialog.result() == QDialog.Accepted:
             self.set_dirty()
@@ -204,7 +204,7 @@ class SettingsWidget(*inherits_from_ui_file_with_name("settingswidget")):
         self.hotkey_settings_dialog.reset()
 
     def on_set_window_filter_button_pressed(self):
-        self.window_filter_dialog.exec_()
+        self.window_filter_dialog.exec()
 
         if self.window_filter_dialog.result() == QDialog.Accepted:
             self.set_dirty()

--- a/lib/autokey/scripting/clipboard_qt.py
+++ b/lib/autokey/scripting/clipboard_qt.py
@@ -4,8 +4,8 @@ QtClipboard Functions
 
 import threading
 
-from PyQt5.QtGui import QClipboard, QImage
-from PyQt5.QtWidgets import QApplication
+from qtpy.QtGui import QClipboard, QImage
+from qtpy.QtWidgets import QApplication
 from autokey.scripting.abstract_clipboard import AbstractClipboard
 
 from pathlib import Path

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -2,6 +2,7 @@ dbus-python
 pyinotify
 python-xlib
 PyGObject
+qtpy
 PyQt5
 QScintilla
 pyhamcrest

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,7 @@ deps =
     pytest-cov
     pytest-timeout
     pytest-xvfb
+    qtpy
 ; Pass args to pytest by including them in the tox call after a `--`, eg tox
 ; -- tests/test_something.py
 commands = pytest {posargs}

--- a/setup.py
+++ b/setup.py
@@ -202,6 +202,7 @@ setup(
     extras_require={
             "QT": [
                 "PyQt5",
+                "qtpy",
                 "QScintilla"
                 ],
             "GTK": [


### PR DESCRIPTION
Replace all `from PyQt5.X import Y` with `from qtpy.X import Y` across the entire Qt UI layer, making the application runnable with either PyQt5 or PyQt6 as the underlying binding.

Key changes:
- Replace PyQt5 imports with qtpy throughout all qtui modules, scripting, interface, and macro modules
- Replace deprecated `exec_()` calls with `exec()` (required by Qt 6)
- Guard `Qt.AA_X11InitThreads` attribute access behind try/except, as it was removed in Qt 6
- Import `Q_CLASSINFO` with a PyQt6 try/except fallback, as it is a SIP-level binding not wrapped by qtpy
- Add `qtpy` to install_requires (setup.py), pip-requirements.txt, setup.cfg tox deps, debian/build_requirements.txt, and debian/control
- Update module availability check in UI_common_functions.py to check for `qtpy` instead of `PyQt5`