### PR TITLE
Update setup cfg indents

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -94,6 +94,8 @@ Other changes
 - Use raw-string format in `window.py` to handle invalid escape sequences.
 - Bump GitHub Action and Python versions.
 - Update white-space in `setup.cfg` for readability and consistency with other lines.
+- Update indentation in the **pytest** section of `setup.cfg` for readability and syntax-correctness.
+
 
 .. _its counterpart: https://github.com/autokey/autokey/blob/master/.github/ISSUE_TEMPLATE/config.yml
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,14 +6,13 @@ test = pytest
 
 [tool:pytest]
 log_cli_level = debug
-testpaths =
-  tests
+testpaths = tests
 norecursedirs = dist build .tox scripts
 addopts =
-#   --cov-report=xml
-; --cov-report=term-missing
-#   --cov-report=html:test_coverage_report_html
-#   --cov-report=annotate:test_coverage_annotated_source
+  #   --cov-report=xml
+  ; --cov-report=term-missing
+  #   --cov-report=html:test_coverage_report_html
+  #   --cov-report=annotate:test_coverage_annotated_source
   # Summarise failed tests at the end, including xfails and skips.
   -r fa
   ; -v


### PR DESCRIPTION
* Remove indent from line 10 by moving it up onto line 9 for readability of the **testpaths** line.
* Fix missing indents in the **addopts** section.
