### PR TITLE
Update setup cfg cleaning up more white space

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -95,6 +95,7 @@ Other changes
 - Bump GitHub Action and Python versions.
 - Update white-space in `setup.cfg` for readability and consistency with other lines.
 - Update indentation in the **pytest** section of `setup.cfg` for readability and syntax-correctness.
+- Remove white-space from **addopts** lines in `setup.cfg` for readability.
 
 
 .. _its counterpart: https://github.com/autokey/autokey/blob/master/.github/ISSUE_TEMPLATE/config.yml

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,10 +9,10 @@ log_cli_level = debug
 testpaths = tests
 norecursedirs = dist build .tox scripts
 addopts =
-  #   --cov-report=xml
+  # --cov-report=xml
   ; --cov-report=term-missing
-  #   --cov-report=html:test_coverage_report_html
-  #   --cov-report=annotate:test_coverage_annotated_source
+  # --cov-report=html:test_coverage_report_html
+  # --cov-report=annotate:test_coverage_annotated_source
   # Summarise failed tests at the end, including xfails and skips.
   -r fa
   ; -v


### PR DESCRIPTION
This removes excess white-space in some of the **addopts** lines inside the **pytest** section for readability.
