### PR TITLE
Use distinct setup.cfg comment types

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -96,6 +96,7 @@ Other changes
 - Update white-space in `setup.cfg` for readability and consistency with other lines.
 - Update indentation in the **pytest** section of `setup.cfg` for readability and syntax-correctness.
 - Remove white-space from **addopts** lines in `setup.cfg` for readability.
+- Use distinct comment types in `setup.cfg` for maintainability.
 
 
 .. _its counterpart: https://github.com/autokey/autokey/blob/master/.github/ISSUE_TEMPLATE/config.yml

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,10 +9,10 @@ log_cli_level = debug
 testpaths = tests
 norecursedirs = dist build .tox scripts
 addopts =
-  # --cov-report=xml
+  ; --cov-report=xml
   ; --cov-report=term-missing
-  # --cov-report=html:test_coverage_report_html
-  # --cov-report=annotate:test_coverage_annotated_source
+  ; --cov-report=html:test_coverage_report_html
+  ; --cov-report=annotate:test_coverage_annotated_source
   # Summarise failed tests at the end, including xfails and skips.
   -r fa
   ; -v
@@ -20,13 +20,13 @@ addopts =
 
 [tox:tox]
 ; envlist = py310,py311,py312,py313,py314
-; Only run test environment by default, so just running `tox` is fast
-; and doesn't include the overhead of coverage or any other build
-; pathways.
-; This may not be the most effective way to do this, but it is the only way I
-; could find.
+# Only run test environment by default, so just running `tox` is fast
+# and doesn't include the overhead of coverage or any other build
+# pathways.
+# This may not be the most effective way to do this, but it is the only way I
+# could find.
 envlist = test
-; Run other environments/tasks with for example `tox -e clean``
+# Run other environments/tasks with for example `tox -e clean``
 
 
 [testenv]


### PR DESCRIPTION
* Use hash-marks for commenting outtext or documentation.
* Use semi-colons for commenting out (disabling) configuration lines or code.

This improves maintainability by using the default behavior of the [Python configparser](https://docs.python.org/3/library/configparser.html#supported-ini-file-structure), which recognizes both of those characters as prefixes for comments.
