### PR TITLE
Sort some setup.cfg sections

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -97,6 +97,7 @@ Other changes
 - Update indentation in the **pytest** section of `setup.cfg` for readability and syntax-correctness.
 - Remove white-space from **addopts** lines in `setup.cfg` for readability.
 - Use distinct comment types in `setup.cfg` for maintainability.
+- Sort some of the `setup.cf` sections for readability and maintainability.
 
 
 .. _its counterpart: https://github.com/autokey/autokey/blob/master/.github/ISSUE_TEMPLATE/config.yml

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,10 +9,10 @@ log_cli_level = debug
 testpaths = tests
 norecursedirs = dist build .tox scripts
 addopts =
-  ; --cov-report=xml
-  ; --cov-report=term-missing
-  ; --cov-report=html:test_coverage_report_html
   ; --cov-report=annotate:test_coverage_annotated_source
+  ; --cov-report=html:test_coverage_report_html
+  ; --cov-report=term-missing
+  ; --cov-report=xml
   # Summarise failed tests at the end, including xfails and skips.
   -r fa
   ; -v
@@ -31,13 +31,13 @@ envlist = test
 
 [testenv]
 deps =
+    dbus-python
+    pyhamcrest >= 2.1.0
+    PyGObject
+    PyQt5
     pytest
     pytest-cov
     pytest-xvfb
-    pyhamcrest >= 2.1.0
-    PyQt5
-    dbus-python
-    PyGObject
 ; Pass args to pytest by including them in the tox call after a `--`, eg tox
 ; -- tests/test_something.py
 commands = pytest {posargs}
@@ -45,11 +45,6 @@ passenv =
     DISPLAY
     DBUS_SESSION_BUS_ADDRESS
     USER
-
-[testenv:test]
-deps = {[testenv]deps}
-commands = pytest --no-cov {posargs}
-passenv = {[testenv]passenv}
 
 [testenv:clean]
 deps = coverage
@@ -63,6 +58,13 @@ setenv = COVERAGE_FILE = .coverage.{envname}
 commands = pytest --cov={envsitepackagesdir}/autokey --cov-append {posargs}
 passenv = {[testenv]passenv}
 
+[testenv:lint]
+deps = coverage
+    {[testenv]deps}
+    flake8
+commands = flake8 --count --select=E9,F63,F7,F82 --show-source --statistics --builtins=_ --max-complexity=10 --max-line-length=127 lib/autokey
+passenv = {[testenv]passenv}
+
 [testenv:report]
 deps = coverage
 skip_install = true
@@ -71,9 +73,7 @@ commands =
     coverage report
     coverage html
 
-[testenv:lint]
-deps = coverage
-    {[testenv]deps}
-    flake8
-commands = flake8 --count --select=E9,F63,F7,F82 --show-source --statistics --builtins=_ --max-complexity=10 --max-line-length=127 lib/autokey
+[testenv:test]
+deps = {[testenv]deps}
+commands = pytest --no-cov {posargs}
 passenv = {[testenv]passenv}


### PR DESCRIPTION
Sort some of the sections for readability and maintainability because the order of entries in this file is irrelevant since the entire file is read before being used.

* Sort the **addopts** section alphabetically.
* Sort the **deps** section.
* Sort the **testenv** sections alphabetically.
