### PR TITLE
Add xfail marker for Wayland compatibility issue

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,7 +31,6 @@ Important misc changes
 - Bump to all GitHub-supported Python versions to satisfy issue #986.
 - Add `pyasyncore` dependency to `setup.py` for use in Python 3.12 to satisfy issues #946 and #964.
 - Add `libcairo2` dependency to apt-requirements.txt to satisfy runtime requirement.
-
 - Change all instances of **sudo apt** to **sudo apt-get**.
 - Update badges, formatting, wording, links, and information in the **README.rst** file.
 - Various updates to the **README.rst** file to satisfy issue #681.
@@ -97,7 +96,7 @@ Other changes
 - Update indentation in the **pytest** section of `setup.cfg` for readability and syntax-correctness.
 - Remove white-space from **addopts** lines in `setup.cfg` for readability.
 - Use distinct comment types in `setup.cfg` for maintainability.
-
+- Mark the **test_application_runs_without_errors** function as being expected to fail under Wayland.
 
 .. _its counterpart: https://github.com/autokey/autokey/blob/master/.github/ISSUE_TEMPLATE/config.yml
 

--- a/tests/UIs/test_headless.py
+++ b/tests/UIs/test_headless.py
@@ -36,6 +36,7 @@ def get_errors_in_log(caplog):
     return errors
 
 
+@pytest.mark.xfail(reason="Test requires X11/xhost and is incompatible with Wayland.")
 @patch('autokey.dbus_service.AppService' , unittest.mock.MagicMock())
 @patch('sys.argv', ['autokey-app-testing'])
 def test_application_runs_without_errors(caplog, tmp_path):


### PR DESCRIPTION
Mark the **test_application_runs_without_errors** function as being expected to fail under Wayland to prevent the function from causing a **SystemExit: 1** error during tests under Wayland on the grounds that the test requires **X11/xhost**, making it incompatible with Wayland.
