### PR TITLE
Enhance test cases for string and key inputs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -102,7 +102,7 @@ Other changes
 - Mark the **test_application_runs_without_errors** function as being expected to fail under Wayland.
 - Sort some of the `setup.cf` sections for readability and maintainability.
 - Clean up local test-build version and entries.
-
+- Add Wayland-related test-handling to `test_interface.py`.
 
 .. _its counterpart: https://github.com/autokey/autokey/blob/master/.github/ISSUE_TEMPLATE/config.yml
 

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -77,18 +77,25 @@ class TestXrecord():
     # against any _major_ screw-ups.
     @pytest.mark.parametrize(
     "inpt, expected, failmsg", [
-        ["hi.",
-         [(43, 0, 'p'), (43, 0, 'r'), (31, 0, 'p'), (31, 0, 'r'), (60, 0, 'p'), (60, 0, 'r')],
-         "Xinterface doesn't send a normal string properly",
-         ],
-        ["",
-         [],
-         "Xinterface doesn't send an empty string properly",
-         ],
-        [" ",
-         [(65, 0, 'p'), (65, 0, 'r')],
-         "Xinterface doesn't send a space-only string properly",
-         ],
+        pytest.param(
+            "hi.",
+            [(43, 0, 'p'), (43, 0, 'r'), (31, 0, 'p'), (31, 0, 'r'), (60, 0, 'p'), (60, 0, 'r')],
+            "Xinterface doesn't send a normal string properly",
+            id="normal_string"
+        ),
+        pytest.param(
+            "",
+            [],
+            "Xinterface doesn't send an empty string properly",
+            id="empty_string"
+        ),
+        pytest.param(
+            " ",
+            [(65, 0, 'p'), (65, 0, 'r')],
+            "Xinterface doesn't send a space-only string properly",
+            marks=pytest.mark.xfail(reason="Test requires X11/xhost and is incompatible with Wayland."),
+            id="space_only_string"
+        ),
     ])
 
     def test_send_string(self, inpt, expected, failmsg):
@@ -105,6 +112,7 @@ class TestXrecord():
          "Xinterface doesn't send a normal key properly",],
     ])
 
+    @pytest.mark.xfail(reason="Test requires X11/xhost and is incompatible with Wayland.")
     def test_send_key(self, inpt, expected, failmsg):
         with self.event_capture_patch, self.check_workaround_patch:
             self.ifc.send_key(inpt)
@@ -124,6 +132,7 @@ class TestXrecord():
          ],
     ])
 
+    @pytest.mark.xfail(reason="Test requires X11/xhost and is incompatible with Wayland.")
     def test_send_modified_key(self, inpt, mods, expected, failmsg):
         with self.event_capture_patch, self.check_workaround_patch:
             self.ifc.send_modified_key(inpt, mods)


### PR DESCRIPTION
Add wrappers and xfail markers for Wayland compatibility issues:
* Wrap three blocks of top-level code with **pytest.param()**, each with a unique ID, to convert them into addressable test-units for easier log and maintenance referencing:
  * Wrap the block of code that sends a normal string to identify it as the **normal_string** test-unit and protect its complexity.
  * Wrap the block of code that sends an empty string to identify it as the **empty_string** test-unit.
  * Wrap the block of code that sends a space-only string to identify it as the **space_only_string** test-unit and mark it as expected to fail under Wayland due to its reliance on **X11/xhost**.
* Mark the **test_send_key** function as expected to fail under Wayland due to its reliance on **X11/xhost**.
* Mark the **test_send_modified_key** function as being expected to fail under Wayland due to its reliance on **X11/xhost**.
