### PR TITLE
Fix Window import error on scripting tests

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -102,7 +102,7 @@ Other changes
 - Mark the **test_application_runs_without_errors** function as being expected to fail under Wayland.
 - Sort some of the `setup.cf` sections for readability and maintainability.
 - Clean up local test-build version and entries.
-
+- Handle Window import error on scripting tests in `lib/autokey/scripting/__init__.py`.
 
 .. _its counterpart: https://github.com/autokey/autokey/blob/master/.github/ISSUE_TEMPLATE/config.yml
 

--- a/lib/autokey/scripting/__init__.py
+++ b/lib/autokey/scripting/__init__.py
@@ -46,7 +46,5 @@ elif autokey.common.USED_UI_TYPE == "headless":
 
 if autokey.common.SESSION_TYPE == "wayland":
     from .window_gnome import Window
-    pass
-elif autokey.common.SESSION_TYPE == "x11":
-    from .window import Window
-    pass
+else:
+    from autokey.scripting.window import Window


### PR DESCRIPTION
Update the final conditional block in the `lib/autokey/scripting/__init__.py` file to handle the Window import error:
* Add the full path to the **Window** import statement in the final clause so that **Window** can be found and imported under **Xorg**.
* Replace the `elif autokey.common.SESSION_TYPE == "x11":` line with the `else:` line in the final clause for broader scope to include not only access by a user in a Xorg session, but also headless access by the CI or local testing utilities, both of which are also reliant on Xorg.
* Remove the **pass** statements that do nothing from both clauses for cleaner code and to prevent confusion.








