### PR TITLE
Bump AutoKey version

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -56,7 +56,7 @@ Important misc changes
 - Bump the AutoKey version to 0.96.1 in the **autokey.spec** file to satisfy part of issue #227.
 - Fix erroneous `window.close` in place of `window.resize_move` in documentation
 - Adds GNOME Window Extension for interacting with Windows on x11/wayland
-
+- Bump AutoKey version to **0.97.0~beta0** in `debian/changelog`, `fedora/autokey.spec`, and `lib/autokey/common.py`.
 
 Features
 ---------

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+autokey (0.97.0~beta0) noble; urgency=medium
+
+  * First beta release of the new version.
+
+ -- Elliria <Elliria@users.noreply.github.com>  Sun, 03 May 2026 11:42:00 -0400
+
 autokey (0.95.10-0) bionic; urgency=medium
 
   [ Thomas Hess ]

--- a/fedora/autokey.spec
+++ b/fedora/autokey.spec
@@ -1,7 +1,7 @@
 %{?python_enable_dependency_generator}
 Name:		autokey
-Version:	0.96.0
-Release:	2%{?dist}
+Version:	0.97.0~beta0
+Release:	1%{?dist}
 Summary:	Desktop automation utility
 
 
@@ -192,6 +192,9 @@ install -m 644 -D --target-dir=%{buildroot}%{_datadir}/autokey/gnome-shell-exten
 %{_mandir}/man1/autokey-qt.1*
 
 %changelog
+* Sun May 03 2026 Elliria <Elliria@users.noreply.github.com> - 0.97.0~beta0-1
+- Update to 0.97.0~beta0
+
 * Mon Jan 22 2024 Fedora Release Engineering <releng@fedoraproject.org> - 0.96.0-5
 - Rebuilt for https://fedoraproject.org/wiki/Fedora_40_Mass_Rebuild
 

--- a/lib/autokey/common.py
+++ b/lib/autokey/common.py
@@ -35,7 +35,7 @@ LOCK_FILE = os.path.join(RUN_DIR, "autokey.pid")
 
 APP_NAME = "autokey"
 CATALOG = ""
-VERSION = "0.96.1"
+VERSION = "0.97.0~beta0"
 HOMEPAGE = "https://github.com/autokey/autokey"
 AUTHOR = 'Chris Dekter'
 AUTHOR_EMAIL = 'cdekter@gmail.com'


### PR DESCRIPTION
Making it official that the **develop** branch is working on the first beta of version 0.97.0.

* Bump AutoKey version in:
  * [debian/changelog](https://github.com/autokey/autokey/blob/develop/debian/changelog) -- Add a new section for the new version.
  * [fedora/autokey.spec](https://github.com/autokey/autokey/blob/develop/fedora/autokey.spec) -- Update the existing section with the version number, update the release to 1 since it will be the first release, and add a %changelog entry referencing that change.
  * [lib/autokey/common.py](https://github.com/autokey/autokey/blob/develop/lib/autokey/common.py) -- Update the version line.

