### PR TITLE
Enable coverage tests

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -105,6 +105,7 @@ Other changes
 - Update `setup.cfg` comments (fix typo, succinctness, punctuation).
 - Add Wayland-related test-handling to `test_interface.py`.
 - Handle Window import error on scripting tests in `lib/autokey/scripting/__init__.py`.
+- Enable **coverage** tests.
 
 .. _its counterpart: https://github.com/autokey/autokey/blob/master/.github/ISSUE_TEMPLATE/config.yml
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,7 @@ norecursedirs = dist build .tox scripts
 addopts =
   ; --cov-report=annotate:test_coverage_annotated_source
   ; --cov-report=html:test_coverage_report_html
-  ; --cov-report=term-missing
+  --cov-report=term-missing
   ; --cov-report=xml
   # Summarize failed tests at the end, including xfails and skips:
   -r fa


### PR DESCRIPTION
Enable the **--cov-report=term-missing** line in the [setup.cfg](https://github.com/autokey/autokey/blob/develop/setup.cfg) file to enable **coverage** tests. This prevents the **autokey module not found error** when attempts are made to run **coverage** tests and, thus, allowing the tests to run.