### PR TITLE
Clean up and expand .gitignore test and IDE exclusions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,12 +4,11 @@
 __pycache__
 *.egg-info
 *.pyc
-.tox/
-build/*
 lib/autokey/qtui/resources/icons/
 
-# build artifacts
+# Build artifacts
 autokey-gnome-extension/autokey-gnome-extension@autokey.shell-extension.zip
+build/
 
 # Environments
 .env
@@ -20,9 +19,16 @@ ENV/
 env.bak/
 venv.bak/
 
-# IDE's
+# IDE
 .idea
 .vscode
 
+# Tests
 test_coverage_annotated_source/
 test_coverage_report_html/
+.coverage
+.coverage.*
+htmlcov/
+*.lcov
+.pytest_cache/
+.tox/

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -105,6 +105,7 @@ Other changes
 - Update `setup.cfg` comments (fix typo, succinctness, punctuation).
 - Add Wayland-related test-handling to `test_interface.py`.
 - Handle Window import error on scripting tests in `lib/autokey/scripting/__init__.py`.
+- Clean up and expand test and IDE exclusions in the `.gitignore` file.
 
 .. _its counterpart: https://github.com/autokey/autokey/blob/master/.github/ISSUE_TEMPLATE/config.yml
 


### PR DESCRIPTION
Clean up and expand the [.gitignore](https://github.com/autokey/autokey/blob/develop/.gitignore) list that prevents certain directories and files from being accidentally added to the repository:
* Change the **# build artifacts** section header to sentence-case for consistency with the others.
* Move the `build/*` entry to the **# Build artifacts** section.
* Replace the `build/*` entry with `build/` so that not only will the files in the directory be ignored, but the directory, itself, will also be ignored.
* Remove the apostrophe and s from **# IDE's** section header for readability.
* Create a **# Tests** section header for the two test entries.
* Add these new entries to the **# Tests** section so these artifacts will also be ignored:
  ```
  .coverage
  .coverage.*
  htmlcov/
  *.lcov
  .pytest_cache/
  ```
* Move the `.tox/` entry to the new **# Tests** section header.
