### PR TITLE
Fix typos in mouse documentation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -56,6 +56,7 @@ Important misc changes
 - Bump the AutoKey version to 0.96.1 in the **autokey.spec** file to satisfy part of issue #227.
 - Fix erroneous `window.close` in place of `window.resize_move` in documentation
 - Adds GNOME Window Extension for interacting with Windows on x11/wayland
+- Fix typos in mouse documentation (**window** --> **screen**).
 
 
 Features

--- a/lib/autokey/scripting/mouse.py
+++ b/lib/autokey/scripting/mouse.py
@@ -67,8 +67,8 @@ class Mouse:
 
         Usage: C{mouse.click_absolute(x, y, button)}
 
-        :param x: x-coordinate in pixels, relative to upper left corner of window
-        :param y: y-coordinate in pixels, relative to upper left corner of window
+        :param x: x-coordinate in pixels, relative to upper left corner of screen
+        :param y: y-coordinate in pixels, relative to upper left corner of screen
         :param button: mouse button to simulate (left=1, middle=2, right=3)
         """
         self.interface.send_mouse_click(x, y, button, False)


### PR DESCRIPTION
Replace 2 typos of **window** with **screen** in the **click_absolute** function in the [lib/autokey/scripting/mouse.py](https://github.com/Elliria/autokey/blob/master/lib/autokey/scripting/mouse.py) file.
