### PR TITLE
Add enhancements to setup cfg

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -109,6 +109,7 @@ Other changes
 - Handle Window import error on scripting tests in `lib/autokey/scripting/__init__.py`.
 - Clean up and expand test and IDE exclusions in the `.gitignore` file.
 - Enable **coverage** tests.
+- Add measurement and timeout and blame settings to `setup.cfg` for more robust testing. 
 
 .. _its counterpart: https://github.com/autokey/autokey/blob/master/.github/ISSUE_TEMPLATE/config.yml
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,6 +9,7 @@ log_cli_level = debug
 testpaths = tests
 norecursedirs = dist build .tox scripts
 addopts =
+  --cov=lib/autokey
   ; --cov-report=annotate:test_coverage_annotated_source
   ; --cov-report=html:test_coverage_report_html
   --cov-report=term-missing
@@ -25,6 +26,7 @@ addopts =
 envlist = test
 # Run other environments/tasks with, for example: `tox -e clean``
 
+
 [testenv]
 deps =
     dbus-python
@@ -33,6 +35,7 @@ deps =
     PyQt5
     pytest
     pytest-cov
+    pytest-timeout
     pytest-xvfb
 ; Pass args to pytest by including them in the tox call after a `--`, eg tox
 ; -- tests/test_something.py
@@ -51,7 +54,7 @@ commands = coverage erase
 deps = coverage
     {[testenv]deps}
 setenv = COVERAGE_FILE = .coverage.{envname}
-commands = pytest --cov={envsitepackagesdir}/autokey --cov-append {posargs}
+commands = pytest --cov={envsitepackagesdir}/autokey --cov-append --cov-context=test {posargs}
 passenv = {[testenv]passenv}
 
 [testenv:lint]
@@ -73,3 +76,10 @@ commands =
 deps = {[testenv]deps}
 commands = pytest --no-cov {posargs}
 passenv = {[testenv]passenv}
+
+
+[coverage:html]
+show_contexts = True
+
+[coverage:run]
+dynamic_context = test_function


### PR DESCRIPTION
Add measurement and timeout and blame settings to `setup.cfg` for more robust testing:
* Add the **--cov=lib/autokey** line to the **pytest** section to tell the pytest-cov plugin to measure and report code coverage specifically for the autokey libraries (basically, you get more results) and to ensure that running **pytest** in a terminal outside of **tox** will work.
* Add a missing blank line between sections for consistency with the rest of the document.
* Add **pytest-timeout** as a **[testenv]** dependency to handle timing issues.
* Add the **[coverage:html]** and **[coverage:run]** sections to the bottom of the setup.cfg file to satisfy the .[coveragerc](https://github.com/autokey/autokey/blob/develop/.coveragerc) file which contains the **show_contexts = true** line that tells **coverage** to track which test affects which line of code: 
* Add the **--cov-context=test** option to the **commands** entry in the **[testenv:coverage]** section as an on-switch for measurement during execution and to provide extra data in the testing HTML report.
