### PR TITLE
Setup.cfg cross-version harmony

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -111,6 +111,8 @@ Other changes
 - Enable **coverage** tests.
 - Add measurement and timeout and blame settings to `setup.cfg` for more robust testing.
 - Sort the packages in `apt-requirements.txt` alphabetically for easier comparison on changes.
+- Pin **PyGObject** version in `setup.cfg` to ensure cross-version harmony.
+
 
 .. _its counterpart: https://github.com/autokey/autokey/blob/master/.github/ISSUE_TEMPLATE/config.yml
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ envlist = test
 deps =
     dbus-python
     pyhamcrest >= 2.1.0
-    PyGObject
+    PyGObject<=3.50.0
     PyQt5
     pytest
     pytest-cov


### PR DESCRIPTION
Update the [Setup.cfg](https://github.com/autokey/autokey/blob/develop/setup.cfg) file:
* Pin the **PyGObject** version in the **[testenv]** section to version **3.50.0** or lower to ensure cross-version harmony in both **Ubuntu 22.04** and **Ubuntu 24.04+**.
