### PR TITLE
Fix triggered abbreviation for immediate scripts

### DIFF
--- a/lib/autokey/service.py
+++ b/lib/autokey/service.py
@@ -517,7 +517,7 @@ class ScriptRunner:
         backspaces, trigger_character = script.process_buffer(buffer)
         self.mediator.send_backspace(backspaces)
 
-        self._set_triggered_abbreviation(scope, buffer, trigger_character)
+        self._set_triggered_abbreviation(scope, script, buffer, trigger_character)
         if script.path is not None:
             # Overwrite __file__ to contain the path to the user script instead of the path to this service.py file.
             scope["__file__"] = script.path
@@ -577,11 +577,16 @@ class ScriptRunner:
         return script_code, script_name
 
     @staticmethod
-    def _set_triggered_abbreviation(scope: dict, buffer: str, trigger_character: str):
+    def _set_triggered_abbreviation(
+            scope: dict,
+            script: autokey.model.script.Script,
+            buffer: str,
+            trigger_character: str):
         """Provide the triggered abbreviation to the executed script, if any"""
         engine = scope["engine"]  # type: autokey.scripting.Engine
         if buffer:
-            triggered_abbreviation = buffer[:-len(trigger_character)]
+            configured_abbreviation = script._get_trigger_abbreviation(buffer)
+            _, triggered_abbreviation, _ = script._partition_input(buffer, configured_abbreviation)
 
             logger.debug(
                 "Triggered a Script by an abbreviation. Setting it for engine.get_triggered_abbreviation(). "

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,5 +1,4 @@
 # Copyright (C) 2021 BlueDrink9
-
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
@@ -27,10 +26,13 @@ from tests.engine_helpers import *
 import tests.helpers_for_tests as testhelpers
 
 import autokey.model.folder
+import autokey.model.helpers
+import autokey.model.script
 from autokey.configmanager import configmanager
 from autokey.configmanager.configmanager import ConfigManager
 from autokey.service import Service
 from autokey.service import PhraseRunner
+from autokey.service import ScriptRunner
 import autokey.service
 from autokey.scripting import Engine
 
@@ -59,3 +61,30 @@ def test_start(tmp_path):
     s = Service(app)
     s.start()
     s.shutdown()
+
+
+def create_script(abbreviation, trigger_immediately=False, ignore_case=False):
+    script = autokey.model.script.Script("script", "")
+    script.add_abbreviation(abbreviation)
+    script.set_modes([autokey.model.helpers.TriggerMode.ABBREVIATION])
+    script.immediate = trigger_immediately
+    script.ignoreCase = ignore_case
+    script.parent = MagicMock()
+    return script
+
+
+@pytest.mark.parametrize("buffer, abbreviation, immediate, ignore_case, expected", [
+    ("abbr ", "abbr", False, False, ("abbr", " ")),
+    ("prefix abbr ", "abbr", False, False, ("abbr", " ")),
+    ("abbr", "abbr", True, False, ("abbr", "")),
+    ("ABBR", "abbr", True, True, ("ABBR", "")),
+])
+def test_set_triggered_abbreviation_uses_typed_abbreviation(
+        buffer, abbreviation, immediate, ignore_case, expected):
+    script = create_script(abbreviation, immediate, ignore_case)
+    _, trigger_character = script.process_buffer(buffer)
+    engine = MagicMock()
+
+    ScriptRunner._set_triggered_abbreviation({"engine": engine}, script, buffer, trigger_character)
+
+    engine._set_triggered_abbreviation.assert_called_once_with(*expected)


### PR DESCRIPTION
## Summary
- Fix engine.get_triggered_abbreviation() for scripts triggered by immediate abbreviations
- Derive the typed abbreviation from the script's abbreviation matching helpers instead of slicing with an empty trigger character
- Add regression coverage for normal, prefixed, immediate, and case-insensitive abbreviation triggers

Fixes #948.

## Verification
- python -m py_compile lib\autokey\service.py tests\test_service.py
- Focused local logic check for immediate abbreviation extraction

I attempted to run pytest locally, but this Windows environment was missing pytest/PyHamcrest/packaging and dependency installation timed out. The added test is intended to cover the reported regression directly.

Disclosure: this PR was prepared with AI assistance and reviewed before submission.