### PR TITLE
Harden Wayland preflight edge cases

### DIFF
--- a/lib/autokey/wayland_checks.py
+++ b/lib/autokey/wayland_checks.py
@@ -2,6 +2,7 @@
 #  desktop environment and that the prereqs that desktop environment needs are 
 #  in place.
 
+import getpass
 import grp
 import os
 import subprocess
@@ -18,11 +19,12 @@ def waylandChecks():
 
     try:
         #  only do this stuff when running under Wayland
-        if os.environ['XDG_SESSION_TYPE'] != "wayland":
+        if os.environ.get('XDG_SESSION_TYPE') != "wayland":
             return True
 
         #  Check if running on a supported desktop environment
-        if os.environ['XDG_SESSION_DESKTOP'] == 'gnome' or 'GNOME_DESKTOP_SESSION_ID' in os.environ:
+        session_desktop = os.environ.get('XDG_SESSION_DESKTOP', '')
+        if session_desktop.lower() == 'gnome' or 'GNOME_DESKTOP_SESSION_ID' in os.environ:
             logger.debug(f"waylandChecks() found AutoKey running under a supported desktop environment")
         else:
             logger.debug(f"waylandChecks() found AutoKey running under an unsupported desktop environment, displaying popup.")
@@ -50,13 +52,18 @@ def waylandChecks():
 
     #  Gnome check: is the user in the input user group"
     group = 'input'
-    user = os.getlogin()
-    input_group = grp.getgrnam(group)
-    if user in input_group.gr_mem or os.geteuid() == 0:
-        logger.debug(f'waylandChecks() found the "{user}" userid in the "{group}" user group.')
-    else:
-        logger.critical(f'waylandChecks() did not find the "{user}" userid in the "{group}" user group, displaying popup.')
+    user = getpass.getuser()
+    try:
+        input_group = grp.getgrnam(group)
+    except KeyError:
+        logger.critical(f'waylandChecks() did not find the "{group}" user group, displaying popup.')
         show_popup = True
+    else:
+        if user in input_group.gr_mem or os.geteuid() == 0:
+            logger.debug(f'waylandChecks() found the "{user}" userid in the "{group}" user group.')
+        else:
+            logger.critical(f'waylandChecks() did not find the "{user}" userid in the "{group}" user group, displaying popup.')
+            show_popup = True
 
     #  Gnome check: have write access to the /dev/uinput device?
     if os.access('/dev/uinput', os.W_OK):
@@ -70,14 +77,14 @@ def waylandChecks():
         #  This is Gnome-specific, other DTEs added in the future may need 
         #  different messages
         title = 'AutoKey System Configuration Needed'
-        message = f'Your user id is not configured to run AutoKey under Waland.  If this is your <b>first time</b> running AutoKey, try <b>rebooting</b> your system and starting AutoKey again.  Otherwise, try entering these two commands, then rebooting:<br /><br />sudo usermod -a -G "{group}" "{user}"<br /><br />gnome-extensions install --force /usr/share/autokey/gnome-shell-extension/autokey-gnome-extension@autokey.shell-extension.zip'
+        message = f'Your user id is not configured to run AutoKey under Wayland.  If this is your <b>first time</b> running AutoKey, try <b>rebooting</b> your system and starting AutoKey again.  Otherwise, try entering these two commands, then rebooting:<br /><br />sudo usermod -a -G "{group}" "{user}"<br /><br />gnome-extensions install --force /usr/share/autokey/gnome-shell-extension/autokey-gnome-extension@autokey.shell-extension.zip'
         __show_popup(title, message)
         return False
 
     return True
 
 def __show_unsupported_desktop_popup():
-        dte = os.environ['XDG_SESSION_DESKTOP']
+        dte = os.environ.get('XDG_SESSION_DESKTOP') or os.environ.get('DESKTOP_SESSION') or 'unknown'
         title = 'Unsupported Desktop Environment'
         message = f'AutoKey does not support the "{dte}" desktop environment on a system that uses the Wayland window manager like this one. The "{dte}" desktop environment is supported under X11, but not here under Wayland.  Future development may remove this restriction, please stay tuned.'
         __show_popup(title, message)

--- a/tests/test_wayland_checks.py
+++ b/tests/test_wayland_checks.py
@@ -1,0 +1,77 @@
+import types
+
+import autokey.wayland_checks as wayland_checks
+
+
+def test_wayland_checks_passes_without_session_type(monkeypatch):
+    monkeypatch.delenv("XDG_SESSION_TYPE", raising=False)
+
+    assert wayland_checks.waylandChecks() is True
+
+
+def test_wayland_checks_passes_on_x11(monkeypatch):
+    monkeypatch.setenv("XDG_SESSION_TYPE", "x11")
+
+    assert wayland_checks.waylandChecks() is True
+
+
+def test_wayland_checks_handles_missing_desktop_name(monkeypatch):
+    messages = []
+    monkeypatch.setenv("XDG_SESSION_TYPE", "wayland")
+    monkeypatch.delenv("XDG_SESSION_DESKTOP", raising=False)
+    monkeypatch.delenv("DESKTOP_SESSION", raising=False)
+    monkeypatch.delenv("GNOME_DESKTOP_SESSION_ID", raising=False)
+    monkeypatch.setattr(
+        wayland_checks,
+        "__show_popup",
+        lambda title, message: messages.append((title, message)),
+    )
+
+    assert wayland_checks.waylandChecks() is False
+    assert messages
+    assert '"unknown"' in messages[0][1]
+
+
+def test_wayland_checks_uses_noninteractive_user_lookup(monkeypatch):
+    class InputGroup:
+        gr_mem = ["autokey-user"]
+
+    def run_gnome_extensions(*args, **kwargs):
+        return types.SimpleNamespace(stdout=b"Enabled: Yes")
+
+    monkeypatch.setenv("XDG_SESSION_TYPE", "wayland")
+    monkeypatch.setenv("XDG_SESSION_DESKTOP", "gnome")
+    monkeypatch.setattr(wayland_checks.subprocess, "run", run_gnome_extensions)
+    monkeypatch.setattr(wayland_checks.os, "getlogin", lambda: (_ for _ in ()).throw(OSError("no tty")))
+    monkeypatch.setattr(wayland_checks.os, "geteuid", lambda: 1000, raising=False)
+    monkeypatch.setattr(wayland_checks.os, "access", lambda path, mode: True)
+    monkeypatch.setattr(wayland_checks.getpass, "getuser", lambda: "autokey-user")
+    monkeypatch.setattr(wayland_checks.grp, "getgrnam", lambda group: InputGroup())
+
+    assert wayland_checks.waylandChecks() is True
+
+
+def test_wayland_checks_reports_missing_input_group(monkeypatch):
+    messages = []
+
+    def run_gnome_extensions(*args, **kwargs):
+        return types.SimpleNamespace(stdout=b"Enabled: Yes")
+
+    def missing_group(group):
+        raise KeyError(group)
+
+    monkeypatch.setenv("XDG_SESSION_TYPE", "wayland")
+    monkeypatch.setenv("XDG_SESSION_DESKTOP", "gnome")
+    monkeypatch.setattr(wayland_checks.subprocess, "run", run_gnome_extensions)
+    monkeypatch.setattr(wayland_checks.os, "access", lambda path, mode: True)
+    monkeypatch.setattr(wayland_checks.getpass, "getuser", lambda: "autokey-user")
+    monkeypatch.setattr(wayland_checks.grp, "getgrnam", missing_group)
+    monkeypatch.setattr(
+        wayland_checks,
+        "__show_popup",
+        lambda title, message: messages.append((title, message)),
+    )
+
+    assert wayland_checks.waylandChecks() is False
+    assert messages
+    assert "input" in messages[0][1]


### PR DESCRIPTION
## Summary
- Treat missing or non-Wayland XDG_SESSION_TYPE as a no-op for the Wayland preflight check.
- Avoid KeyError when an unsupported Wayland session has no XDG_SESSION_DESKTOP value.
- Use non-interactive-safe user lookup and report a missing input group instead of crashing.
- Add focused coverage for the new preflight edge cases.

## Why
This is a focused follow-up for #87 against the current develop branch. It improves the existing Wayland path without replacing the broader implementation work, especially for run-from-source, CI, and partially configured sessions where startup should fail predictably or continue when not actually under Wayland.

## Testing
- git diff --check
- python -m py_compile lib/autokey/wayland_checks.py tests/test_wayland_checks.py
- manual wayland_checks smoke script on Windows with a stubbed Linux grp module

Not run locally: pytest tests/test_wayland_checks.py --no-cov, because pytest is not installed in this environment.

/claim #87