### PR TITLE
Replace imghdr usage for Python 3.13

### DIFF
--- a/lib/autokey/scripting/highlevel.py
+++ b/lib/autokey/scripting/highlevel.py
@@ -6,7 +6,6 @@ import time
 import os
 import subprocess
 import tempfile
-import imghdr
 import struct
 
 
@@ -72,9 +71,12 @@ def get_png_dim(filepath: str) -> int:
     @returns: (width, height).
     @raise Exception: Raised if the file is not a png
     """
-    if not imghdr.what(filepath) == 'png':
+    with open(filepath, 'rb') as image_file:
+        head = image_file.read(24)
+
+    if len(head) < 24 or head[:8] != b'\x89PNG\r\n\x1a\n':
         raise Exception("not PNG")
-    head = open(filepath, 'rb').read(24)
+
     return struct.unpack('!II', head[16:24])
 
 
@@ -166,4 +168,3 @@ def acknowledge_gnome_notification():
     mouse_click(LEFT)
     time.sleep(.2)
     mouse_move(x0, y0)
-

--- a/tests/scripting_api/test_highlevel.py
+++ b/tests/scripting_api/test_highlevel.py
@@ -1,0 +1,37 @@
+import importlib.util
+import struct
+from pathlib import Path
+
+import pytest
+
+
+def _load_highlevel_module():
+    repo_root = Path(__file__).parents[2]
+    module_path = repo_root / "lib" / "autokey" / "scripting" / "highlevel.py"
+    spec = importlib.util.spec_from_file_location("highlevel", module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+get_png_dim = _load_highlevel_module().get_png_dim
+
+
+def test_get_png_dim_returns_png_dimensions(tmp_path):
+    png_path = tmp_path / "image.png"
+    png_path.write_bytes(
+        b"\x89PNG\r\n\x1a\n"
+        + (13).to_bytes(4, "big")
+        + b"IHDR"
+        + struct.pack("!II", 123, 456)
+    )
+
+    assert get_png_dim(str(png_path)) == (123, 456)
+
+
+def test_get_png_dim_rejects_non_png(tmp_path):
+    not_png_path = tmp_path / "image.txt"
+    not_png_path.write_text("not a png")
+
+    with pytest.raises(Exception, match="not PNG"):
+        get_png_dim(str(not_png_path))


### PR DESCRIPTION
Fixes #961.

Python 3.13 removed the stdlib `imghdr` module, which currently prevents `autokey.scripting.highlevel` from importing on Fedora 41 / Python 3.13.

This replaces the `imghdr.what(..., "png")` check with a direct PNG signature check before reading the IHDR width and height fields. It keeps the existing dependency-free behavior and preserves the current `not PNG` exception message.

Tested with:

```console
PYTHONPATH=lib python3 -m pytest -o addopts='' tests/scripting_api/test_highlevel.py
```
