### PR TITLE
Update common py version

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -58,7 +58,7 @@ Important misc changes
 - Adds GNOME Window Extension for interacting with Windows on x11/wayland
 - Fix typos in mouse documentation (**window** --> **screen**).
 - Bump AutoKey version to **0.97.0~beta0** in `debian/changelog`, `fedora/autokey.spec`, and `lib/autokey/common.py`.
-- Bump the VERSION to **0.97.0-beta.0** in `lib/autokey/common.py] for compliance with [PEP 440](https://peps.python.org/pep-0440/).
+- Bump the VERSION to **0.97.0-beta.0** in `lib/autokey/common.py` for compliance with `PEP 440`_.
 
 
 Features
@@ -117,6 +117,7 @@ Other changes
 
 
 .. _its counterpart: https://github.com/autokey/autokey/blob/master/.github/ISSUE_TEMPLATE/config.yml
+.. _PEP 440: https://peps.python.org/pep-0440/
 
 Version 0.96.0-beta.9
 ============================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -57,8 +57,9 @@ Important misc changes
 - Fix erroneous `window.close` in place of `window.resize_move` in documentation
 - Adds GNOME Window Extension for interacting with Windows on x11/wayland
 - Fix typos in mouse documentation (**window** --> **screen**).
-
 - Bump AutoKey version to **0.97.0~beta0** in `debian/changelog`, `fedora/autokey.spec`, and `lib/autokey/common.py`.
+- Bump the VERSION to **0.97.0-beta.0** in `lib/autokey/common.py] for compliance with [PEP 440](https://peps.python.org/pep-0440/).
+
 
 Features
 ---------

--- a/lib/autokey/common.py
+++ b/lib/autokey/common.py
@@ -35,7 +35,7 @@ LOCK_FILE = os.path.join(RUN_DIR, "autokey.pid")
 
 APP_NAME = "autokey"
 CATALOG = ""
-VERSION = "0.97.0~beta0"
+VERSION = "0.97.0-beta.0"
 HOMEPAGE = "https://github.com/autokey/autokey"
 AUTHOR = 'Chris Dekter'
 AUTHOR_EMAIL = 'cdekter@gmail.com'


### PR DESCRIPTION
Replace the `VERSION = "0.97.0~beta0"` line with the `VERSION = "0.97.0-beta.0"` line to bring the [lib/autokey/common.py](https://github.com/autokey/autokey/blob/develop/lib/autokey/common.py) file into compliance with [PEP 440](https://peps.python.org/pep-0440/) since the tilde that was recently used isn't considered valid, as mentioned in [PR #1117](https://github.com/autokey/autokey/pull/1117).
