### PR TITLE
fix: remove imghdr dependency from PNG size helper

### DIFF
--- a/lib/autokey/scripting/highlevel.py
+++ b/lib/autokey/scripting/highlevel.py
@@ -6,7 +6,6 @@ import time
 import os
 import subprocess
 import tempfile
-import imghdr
 import struct
 
 
@@ -63,18 +62,19 @@ def visgrep(scr: str, pat: str, tolerance: int = 0) -> int:
     return coord
 
 
-def get_png_dim(filepath: str) -> int:
+def get_png_dim(filepath: str) -> tuple[int, int]:
     """
-    Usage: C{get_png_dim(filepath:str) -> (int)}
+    Usage: C{get_png_dim(filepath:str) -> (int, int)}
 
     Finds the dimension of a PNG.
     @param filepath: file path of the PNG.
     @returns: (width, height).
     @raise Exception: Raised if the file is not a png
     """
-    if not imghdr.what(filepath) == 'png':
+    with open(filepath, 'rb') as png_file:
+        head = png_file.read(24)
+    if len(head) < 24 or not head.startswith(b'\x89PNG\r\n\x1a\n'):
         raise Exception("not PNG")
-    head = open(filepath, 'rb').read(24)
     return struct.unpack('!II', head[16:24])
 
 

--- a/tests/scripting_api/test_highlevel.py
+++ b/tests/scripting_api/test_highlevel.py
@@ -1,0 +1,33 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+HIGHLEVEL_PATH = (
+    Path(__file__).resolve().parents[2] / "lib" / "autokey" / "scripting" / "highlevel.py"
+)
+HIGHLEVEL_SPEC = importlib.util.spec_from_file_location("highlevel", HIGHLEVEL_PATH)
+highlevel = importlib.util.module_from_spec(HIGHLEVEL_SPEC)
+HIGHLEVEL_SPEC.loader.exec_module(highlevel)
+
+
+def test_get_png_dim_reads_png_header(tmp_path):
+    png_file = tmp_path / "pattern.png"
+    png_file.write_bytes(
+        b"\x89PNG\r\n\x1a\n"
+        b"\x00\x00\x00\r"
+        b"IHDR"
+        b"\x00\x00\x00\x10"
+        b"\x00\x00\x00\x20"
+    )
+
+    assert highlevel.get_png_dim(str(png_file)) == (16, 32)
+
+
+def test_get_png_dim_rejects_non_png(tmp_path):
+    text_file = tmp_path / "pattern.txt"
+    text_file.write_text("not a png", encoding="utf-8")
+
+    with pytest.raises(Exception, match="not PNG"):
+        highlevel.get_png_dim(str(text_file))


### PR DESCRIPTION
Refs #961.

Summary:
- Remove the deprecated Python 3.13-incompatible imghdr dependency from the PNG size helper.
- Parse PNG dimensions directly from the PNG header.
- Add focused scripting API regression tests.

Validation:
- python -m pytest -o addopts= tests\scripting_api\test_highlevel.py -q
- python -m py_compile lib\autokey\scripting\highlevel.py tests\scripting_api\test_highlevel.py
- rg -n "imghdr" lib tests setup.py pip-requirements.txt apt-requirements.txt
