### PR TITLE
fix: replace imghdr PNG check

### DIFF
--- a/lib/autokey/scripting/highlevel.py
+++ b/lib/autokey/scripting/highlevel.py
@@ -6,7 +6,6 @@ import time
 import os
 import subprocess
 import tempfile
-import imghdr
 import struct
 
 
@@ -63,7 +62,7 @@ def visgrep(scr: str, pat: str, tolerance: int = 0) -> int:
     return coord
 
 
-def get_png_dim(filepath: str) -> int:
+def get_png_dim(filepath: str) -> tuple[int, int]:
     """
     Usage: C{get_png_dim(filepath:str) -> (int)}
 
@@ -72,9 +71,10 @@ def get_png_dim(filepath: str) -> int:
     @returns: (width, height).
     @raise Exception: Raised if the file is not a png
     """
-    if not imghdr.what(filepath) == 'png':
+    with open(filepath, "rb") as f:
+        head = f.read(24)
+    if head[:8] != b"\x89PNG\r\n\x1a\n":
         raise Exception("not PNG")
-    head = open(filepath, 'rb').read(24)
     return struct.unpack('!II', head[16:24])
 
 
@@ -166,4 +166,3 @@ def acknowledge_gnome_notification():
     mouse_click(LEFT)
     time.sleep(.2)
     mouse_move(x0, y0)
-

--- a/tests/test_highlevel.py
+++ b/tests/test_highlevel.py
@@ -1,0 +1,27 @@
+# Copyright (C) 2026
+
+import base64
+
+import pytest
+
+from autokey.scripting.highlevel import get_png_dim
+
+
+PNG_1X1 = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO3ZswAAAABJRU5ErkJggg=="
+)
+
+
+def test_get_png_dim_reads_png_dimensions(tmp_path):
+    png_path = tmp_path / "image.png"
+    png_path.write_bytes(PNG_1X1)
+
+    assert get_png_dim(str(png_path)) == (1, 1)
+
+
+def test_get_png_dim_rejects_non_png(tmp_path):
+    text_path = tmp_path / "note.txt"
+    text_path.write_text("not a png", encoding="utf-8")
+
+    with pytest.raises(Exception, match="not PNG"):
+        get_png_dim(str(text_path))


### PR DESCRIPTION
  ## Issue
  Closes #961

  ## Summary
  Remove the deprecated `imghdr` dependency from `get_png_dim()` and replace it with a direct PNG signature check. Add tests covering valid PNG input and non-PNG
  rejection.

  ## Verification
  - `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTHONPATH=lib python -m pytest -o addopts= tests/test_highlevel.py -q`

  ## Notes
  This keeps the change narrowly scoped to the Fedora 41 / Python 3.13 compatibility bug.
