### PR TITLE
Replace imghdr PNG check

### DIFF
--- a/lib/autokey/scripting/highlevel.py
+++ b/lib/autokey/scripting/highlevel.py
@@ -6,7 +6,6 @@ import time
 import os
 import subprocess
 import tempfile
-import imghdr
 import struct
 
 
@@ -63,7 +62,7 @@ def visgrep(scr: str, pat: str, tolerance: int = 0) -> int:
     return coord
 
 
-def get_png_dim(filepath: str) -> int:
+def get_png_dim(filepath: str) -> tuple[int, int]:
     """
     Usage: C{get_png_dim(filepath:str) -> (int)}
 
@@ -72,9 +71,10 @@ def get_png_dim(filepath: str) -> int:
     @returns: (width, height).
     @raise Exception: Raised if the file is not a png
     """
-    if not imghdr.what(filepath) == 'png':
+    with open(filepath, 'rb') as image_file:
+        head = image_file.read(24)
+    if head[:8] != b'\x89PNG\r\n\x1a\n':
         raise Exception("not PNG")
-    head = open(filepath, 'rb').read(24)
     return struct.unpack('!II', head[16:24])
 
 

--- a/tests/scripting_api/test_highlevel.py
+++ b/tests/scripting_api/test_highlevel.py
@@ -1,0 +1,31 @@
+import importlib.util
+import struct
+from pathlib import Path
+
+import pytest
+
+
+HIGHLEVEL_PATH = Path(__file__).parents[2] / "lib" / "autokey" / "scripting" / "highlevel.py"
+spec = importlib.util.spec_from_file_location("highlevel", HIGHLEVEL_PATH)
+highlevel = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(highlevel)
+
+
+def test_get_png_dim_returns_dimensions(tmp_path):
+    png_file = tmp_path / "sample.png"
+    png_file.write_bytes(
+        b"\x89PNG\r\n\x1a\n"
+        + struct.pack("!I", 13)
+        + b"IHDR"
+        + struct.pack("!II", 640, 480)
+    )
+
+    assert highlevel.get_png_dim(str(png_file)) == (640, 480)
+
+
+def test_get_png_dim_rejects_non_png(tmp_path):
+    text_file = tmp_path / "sample.txt"
+    text_file.write_text("not a png")
+
+    with pytest.raises(Exception, match="not PNG"):
+        highlevel.get_png_dim(str(text_file))


### PR DESCRIPTION
Fixes #961

## Summary

- remove the `imghdr` import from the high-level scripting helpers
- validate PNG files by checking the PNG signature directly
- add focused coverage for successful PNG dimension parsing and non-PNG rejection

## Testing

- `python -m py_compile lib\autokey\scripting\highlevel.py tests\scripting_api\test_highlevel.py`
- manual check of `get_png_dim()` with a generated PNG returned `(640, 480)`
- manual check of `get_png_dim()` with a text file raised `Exception: not PNG`

Note: I could not run the full pytest target in this local environment because `pytest` is not installed.
