### PR TITLE
Fix compatibility: replace imghdr with imagesize

### DIFF
--- a/lib/autokey/scripting/highlevel.py
+++ b/lib/autokey/scripting/highlevel.py
@@ -6,7 +6,7 @@ import time
 import os
 import subprocess
 import tempfile
-import imghdr
+import imagesize
 import struct
 
 
@@ -72,7 +72,11 @@ def get_png_dim(filepath: str) -> int:
     @returns: (width, height).
     @raise Exception: Raised if the file is not a png
     """
-    if not imghdr.what(filepath) == 'png':
+    try:
+        img_format = imagesize.get(filepath)[2]
+        if not img_format or img_format.lower() != 'png':
+            raise Exception("not PNG")
+    except Exception:
         raise Exception("not PNG")
     head = open(filepath, 'rb').read(24)
     return struct.unpack('!II', head[16:24])


### PR DESCRIPTION
Replaced the deprecated imghdr module with imagesize to fix Python 3.13 compatibility.