### PR TITLE
Replace imghdr usage for Python 3.13 compatibility

### DIFF
--- a/lib/autokey/scripting/highlevel.py
+++ b/lib/autokey/scripting/highlevel.py
@@ -6,8 +6,9 @@ import time
 import os
 import subprocess
 import tempfile
-import imghdr
 import struct
+
+PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
 
 
 class PatternNotFound(Exception):
@@ -72,9 +73,10 @@ def get_png_dim(filepath: str) -> int:
     @returns: (width, height).
     @raise Exception: Raised if the file is not a png
     """
-    if not imghdr.what(filepath) == 'png':
-        raise Exception("not PNG")
     head = open(filepath, 'rb').read(24)
+    if not head.startswith(PNG_SIGNATURE):
+        raise Exception("not PNG")
+
     return struct.unpack('!II', head[16:24])
 
 

--- a/tests/scripting_api/test_highlevel.py
+++ b/tests/scripting_api/test_highlevel.py
@@ -1,0 +1,46 @@
+# Copyright (C) 2026 AutoKey contributors
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+import struct
+
+import pytest
+from hamcrest import *
+
+from autokey.scripting.highlevel import get_png_dim
+
+
+def write_png_header(path, width, height):
+    path.write_bytes(
+        b"\x89PNG\r\n\x1a\n"
+        + b"\x00\x00\x00\r"
+        + b"IHDR"
+        + struct.pack("!II", width, height)
+        + b"\x08\x02\x00\x00\x00"
+    )
+
+
+def test_get_png_dim_reads_png_dimensions(tmp_path):
+    png_file = tmp_path / "image.png"
+    write_png_header(png_file, 640, 480)
+
+    assert_that(get_png_dim(str(png_file)), is_(equal_to((640, 480))))
+
+
+def test_get_png_dim_rejects_non_png_file(tmp_path):
+    text_file = tmp_path / "not-image.txt"
+    text_file.write_text("not a png")
+
+    with pytest.raises(Exception, match="not PNG"):
+        get_png_dim(str(text_file))


### PR DESCRIPTION
## Summary
- Replaced the removed `imghdr` module with PNG signature validation.
- Kept `get_png_dim()` behavior for valid PNG files.
- Added tests for PNG dimension parsing and non-PNG rejection.

## Related issue
Fixes #961

## Testing
- Manually verified `get_png_dim()` returns `(640, 480)` for a PNG header.
- Manually verified non-PNG input raises `not PNG`.
- Could not run pytest locally because pytest is not installed in the current Python environment.