### PR TITLE
feat: multi-compositor Wayland support with graceful fallback

### DIFF
--- a/lib/autokey/iomediator/iomediator.py
+++ b/lib/autokey/iomediator/iomediator.py
@@ -22,7 +22,6 @@ import autokey
 from autokey import common
 from autokey.configmanager.configmanager import ConfigManager
 from autokey.configmanager.configmanager_constants import INTERFACE_TYPE
-from autokey.gnome_interface import GnomeExtensionWindowInterface
 from autokey.sys_interface.clipboard import Clipboard
 from autokey.model.phrase import SendMode
 
@@ -70,8 +69,9 @@ class IoMediator(threading.Thread):
             pass
 
         if self.interfaceType == "uinput":
-            logger.debug("Using gnome extension window interface")
-            self.windowInterface = GnomeExtensionWindowInterface()
+            from autokey.wayland_compositor import create_window_interface
+            logger.debug("Wayland session: creating compositor-aware window interface")
+            self.windowInterface = create_window_interface()
         else:
             from autokey.interface import XWindowInterface
             self.windowInterface = XWindowInterface()

--- a/lib/autokey/scripting/__init__.py
+++ b/lib/autokey/scripting/__init__.py
@@ -44,7 +44,18 @@ elif autokey.common.USED_UI_TYPE == "headless":
     # Doesn't actually use anything gtk-specific.
     from .dialog_gtk import GtkDialog as Dialog
 
+# Window scripting API: compositor-aware selection.
+# create_scripting_window() is the preferred factory for runtime use;
+# the Window class imported here is the default used at module import time
+# (before a mediator is available).
 if autokey.common.SESSION_TYPE == "wayland":
-    from .window_gnome import Window
+    from autokey.wayland_compositor import detect_compositor, COMPOSITOR_GNOME
+    if detect_compositor() == COMPOSITOR_GNOME:
+        try:
+            from .window_gnome import Window
+        except Exception:
+            from .window_wayland_fallback import Window
+    else:
+        from .window_wayland_fallback import Window
 else:
     from autokey.scripting.window import Window

--- a/lib/autokey/scripting/window_wayland_fallback.py
+++ b/lib/autokey/scripting/window_wayland_fallback.py
@@ -1,0 +1,174 @@
+# Copyright (C) 2024 AutoKey Contributors
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+Fallback scripting ``Window`` API for Wayland compositors that do not have a
+dedicated AutoKey window interface (e.g., KDE/KWin, Sway, Hyprland).
+
+All methods that require compositor-specific window management return safe
+empty/stub values and emit a warning.  Methods that do not depend on the
+compositor (e.g., ``wait_for_focus``) still work where possible.
+"""
+
+import time
+
+logger = __import__("autokey.logger").logger.get_logger(__name__)
+
+_WAYLAND_LIMITATION_MSG = (
+    "Window management is not supported on this Wayland compositor. "
+    "Only GNOME (via the AutoKey GNOME Shell extension) is currently supported. "
+    "Phrase expansion and hotkeys still work normally."
+)
+
+
+class Window:
+    """
+    Scripting ``Window`` API stub for unsupported Wayland compositors.
+
+    AutoKey scripts that call these methods on an unsupported Wayland
+    compositor will receive empty strings / ``None`` / ``False`` instead of
+    crashing with an unhandled exception.
+    """
+
+    def __init__(self, mediator):
+        self.mediator = mediator
+        logger.warning(_WAYLAND_LIMITATION_MSG)
+
+    # ------------------------------------------------------------------
+    # Title / class queries (use windowInterface if available)
+    # ------------------------------------------------------------------
+
+    def get_active_title(self) -> str:
+        """
+        Get the title of the active window.
+
+        On unsupported Wayland compositors this always returns an empty string.
+        """
+        try:
+            return self.mediator.windowInterface.get_window_title() or ""
+        except Exception:
+            return ""
+
+    def get_active_class(self) -> str:
+        """
+        Get the WM class of the active window.
+
+        On unsupported Wayland compositors this always returns an empty string.
+        """
+        try:
+            return self.mediator.windowInterface.get_window_class() or ""
+        except Exception:
+            return ""
+
+    # ------------------------------------------------------------------
+    # Waiting helpers — still functional via polling
+    # ------------------------------------------------------------------
+
+    def wait_for_focus(self, title: str, timeOut: float = 5) -> bool:
+        """
+        Wait for a window with the given title to gain focus.
+
+        On compositors without window-title support this will always return
+        ``False`` after the timeout because the title cannot be read.
+
+        :param title: title to match (as a regular expression)
+        :param timeOut: seconds to wait before giving up
+        :rtype: bool
+        """
+        import re
+        regex = re.compile(title)
+        waited = 0.0
+        while waited <= timeOut:
+            current = self.get_active_title()
+            if regex.match(current):
+                return True
+            if timeOut == 0:
+                break
+            time.sleep(0.3)
+            waited += 0.3
+        return False
+
+    def wait_for_exist(self, title: str, timeOut: float = 5, by_hex: bool = False) -> bool:
+        """
+        Wait for a window with the given title to be created.
+
+        Always returns ``False`` on unsupported Wayland compositors because the
+        window list cannot be retrieved.
+        """
+        logger.warning(
+            "window.wait_for_exist() is not supported on this Wayland compositor."
+        )
+        return False
+
+    # ------------------------------------------------------------------
+    # Window management — unsupported stubs
+    # ------------------------------------------------------------------
+
+    def _unsupported(self, method_name: str):
+        logger.warning(
+            "window.%s() is not supported on this Wayland compositor.  %s",
+            method_name,
+            _WAYLAND_LIMITATION_MSG,
+        )
+
+    def activate(self, title, switchDesktop=False, matchClass=False, by_hex=False):
+        """Activate the specified window (not supported on this compositor)."""
+        self._unsupported("activate")
+
+    def close(self, title, matchClass=False, by_hex=False):
+        """Close the specified window (not supported on this compositor)."""
+        self._unsupported("close")
+
+    def resize_move(self, title, xOrigin=-1, yOrigin=-1, width=-1, height=-1,
+                    matchClass=False, by_hex=False):
+        """Resize/move the specified window (not supported on this compositor)."""
+        self._unsupported("resize_move")
+
+    def move_to_desktop(self, title, deskNum, matchClass=False, by_hex=False):
+        """Move the window to a desktop (not supported on this compositor)."""
+        self._unsupported("move_to_desktop")
+
+    def switch_desktop(self, deskNum):
+        """Switch to the specified desktop (not supported on this compositor)."""
+        self._unsupported("switch_desktop")
+
+    def set_property(self, title, action, prop, matchClass=False, by_hex=False):
+        """Set a window property (not supported on this compositor)."""
+        self._unsupported("set_property")
+
+    def get_active_geometry(self):
+        """Return the active window geometry (not supported on this compositor)."""
+        self._unsupported("get_active_geometry")
+        return None
+
+    def get_window_geometry(self, title, by_hex=False):
+        """Return the window geometry for the given title (not supported)."""
+        self._unsupported("get_window_geometry")
+        return None
+
+    def get_window_list(self, filter_desktop=-1):
+        """Return a list of windows (not supported on this compositor)."""
+        self._unsupported("get_window_list")
+        return []
+
+    def get_window_hex(self, title):
+        """Return the hex ID of a window (not supported on this compositor)."""
+        self._unsupported("get_window_hex")
+        return None
+
+    def center_window(self, title=":ACTIVE:", win_width=None, win_height=None,
+                      monitor=0, matchClass=False, by_hex=False):
+        """Center the window (not supported on this compositor)."""
+        self._unsupported("center_window")

--- a/lib/autokey/sys_interface/abstract_interface.py
+++ b/lib/autokey/sys_interface/abstract_interface.py
@@ -89,6 +89,7 @@ class AbstractSysInterface(ABC, metaclass=ABCMeta):
     @abstractmethod
     def press_key(self, key_name):
         return
+    @abstractmethod
     def release_key(self, key_name):
         return
     @abstractmethod

--- a/lib/autokey/wayland_checks.py
+++ b/lib/autokey/wayland_checks.py
@@ -1,6 +1,13 @@
 #  When running under Wayland, check if running under a supported
-#  desktop environment and that the prereqs that desktop environment needs are 
+#  desktop environment and that the prereqs that desktop environment needs are
 #  in place.
+#
+#  Supported compositors:
+#    - GNOME (full support via the AutoKey GNOME Shell extension + uinput)
+#    - KDE/KWin, Sway, Hyprland (partial: text expansion + hotkeys via
+#      uinput; window title/class filtering not available yet)
+#  Unsupported compositors emit a clear warning but do NOT abort startup so
+#  that basic functionality remains usable on any Wayland session.
 
 import getpass
 import grp
@@ -15,91 +22,280 @@ except Exception:
     logging.basicConfig(format='%(asctime)s: %(levelname)s: %(message)s', datefmt='%d-%b-%y %H:%M:%S', level=logging.DEBUG)
     logger = logging.getLogger(__name__)
 
-def waylandChecks():
 
-    try:
-        #  only do this stuff when running under Wayland
-        if os.environ.get('XDG_SESSION_TYPE') != "wayland":
-            return True
+# ---------------------------------------------------------------------------
+# Compositor identification helpers
+# ---------------------------------------------------------------------------
 
-        #  Check if running on a supported desktop environment
-        session_desktop = os.environ.get('XDG_SESSION_DESKTOP', '')
-        if session_desktop.lower() == 'gnome' or 'GNOME_DESKTOP_SESSION_ID' in os.environ:
-            logger.debug(f"waylandChecks() found AutoKey running under a supported desktop environment")
-        else:
-            logger.debug(f"waylandChecks() found AutoKey running under an unsupported desktop environment, displaying popup.")
-            __show_unsupported_desktop_popup()
-            return False
-    except Exception as e:
-        logger.exception('Unexpected exception in waylandChecks() while examining environment variables')
-        return False
+def _detect_compositor():
+    """
+    Return a lowercase string identifying the active compositor.
+    Returns one of: 'gnome', 'kde', 'sway', 'hyprland', 'unknown'.
+    """
+    desktop = (
+        os.environ.get("XDG_CURRENT_DESKTOP", "").lower()
+        or os.environ.get("DESKTOP_SESSION", "").lower()
+    )
+    session_desktop = os.environ.get("XDG_SESSION_DESKTOP", "").lower()
 
-    #  show popup message?
-    show_popup = False
+    if (
+        "gnome" in desktop
+        or "gnome" in session_desktop
+        or "GNOME_DESKTOP_SESSION_ID" in os.environ
+    ):
+        return "gnome"
+    if "kde" in desktop or "plasma" in desktop or "kde" in session_desktop:
+        return "kde"
+    if "sway" in desktop or "sway" in session_desktop or "SWAYSOCK" in os.environ:
+        return "sway"
+    if (
+        "hyprland" in desktop
+        or "hyprland" in session_desktop
+        or "HYPRLAND_INSTANCE_SIGNATURE" in os.environ
+    ):
+        return "hyprland"
 
-    #  Gnome check: is the Gnome Shell extension present?
-    ext_id = 'autokey-gnome-extension@autokey'
-    try:
-        proc = subprocess.run(f'gnome-extensions info {ext_id}', shell=True, capture_output=True, check=True)
-        if 'Enabled: Yes' in proc.stdout.decode('utf-8'):
-            logger.debug('waylandChecks() found the AutoKey Gnome Shell extension')
-        else:
-            logger.debug('waylandChecks() found the AutoKey Gnome Shell extension but it is disabled.  Attempting to enable it.')
-            subprocess.run(f'gnome-extensions enable {ext_id}', shell=True, capture_output=True, check=True)
-    except Exception:
-        logger.critical('waylandChecks() did not find the AutoKey Gnome Shell extension, displaying popup')
-        show_popup = True
+    # Process inspection fallback
+    for proc, name in [
+        ("gnome-shell", "gnome"),
+        ("kwin_wayland", "kde"),
+        ("sway", "sway"),
+        ("Hyprland", "hyprland"),
+    ]:
+        try:
+            r = subprocess.run(["pgrep", "-x", proc], capture_output=True, timeout=2)
+            if r.returncode == 0:
+                return name
+        except (subprocess.TimeoutExpired, FileNotFoundError):
+            pass
 
-    #  Gnome check: is the user in the input user group"
-    group = 'input'
+    return "unknown"
+
+
+# ---------------------------------------------------------------------------
+# uinput / input-group checks (required for all Wayland compositors)
+# ---------------------------------------------------------------------------
+
+def _check_uinput_prerequisites():
+    """
+    Check that the user is in the 'input' group and has write access to
+    /dev/uinput.  Returns (ok: bool, message: str).
+    """
+    group = "input"
     user = getpass.getuser()
+    issues = []
+
     try:
         input_group = grp.getgrnam(group)
     except KeyError:
-        logger.critical(f'waylandChecks() did not find the "{group}" user group, displaying popup.')
-        show_popup = True
+        issues.append(f'The "{group}" user group does not exist on this system.')
     else:
-        if user in input_group.gr_mem or os.geteuid() == 0:
-            logger.debug(f'waylandChecks() found the "{user}" userid in the "{group}" user group.')
+        if user not in input_group.gr_mem and os.geteuid() != 0:
+            issues.append(
+                f'User "{user}" is not in the "{group}" group.  '
+                f'Run: sudo usermod -a -G {group} {user}  (then reboot)'
+            )
+
+    if not os.access("/dev/uinput", os.W_OK):
+        issues.append(
+            'No write access to /dev/uinput.  '
+            'Add yourself to the "input" group and reboot, or run: '
+            'sudo chmod a+rw /dev/uinput  (temporary fix).'
+        )
+
+    if issues:
+        return False, "\n".join(issues)
+    return True, ""
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+def waylandChecks():
+    """
+    Perform Wayland pre-flight checks.
+
+    * On X11 sessions: always returns ``True`` immediately.
+    * On Wayland + GNOME: full checks (extension present, input group, uinput).
+    * On Wayland + KDE / Sway / Hyprland: uinput group check only; shows an
+      informational warning about limited window-filtering support but still
+      returns ``True`` so AutoKey can start.
+    * On Wayland + unknown compositor: logs a warning and returns ``True``
+      (best-effort mode).
+
+    :returns: ``True`` if AutoKey should continue starting; ``False`` if a
+              critical prerequisite is missing and the user has been informed.
+    """
+    try:
+        if os.environ.get("XDG_SESSION_TYPE") != "wayland":
+            return True
+
+        compositor = _detect_compositor()
+        logger.info(f"waylandChecks(): detected Wayland compositor: {compositor}")
+
+        if compositor == "gnome":
+            return _gnome_checks()
+        elif compositor in ("kde", "sway", "hyprland"):
+            return _partial_wayland_checks(compositor)
         else:
-            logger.critical(f'waylandChecks() did not find the "{user}" userid in the "{group}" user group, displaying popup.')
-            show_popup = True
+            return _unknown_compositor_checks()
 
-    #  Gnome check: have write access to the /dev/uinput device?
-    if os.access('/dev/uinput', os.W_OK):
-        logger.debug(f'waylandChecks() found write access to the /dev/uinput device')
-    else:
-        logger.critical(f'waylandChecks() did not find write access to the /dev/uinput device')
+    except Exception as e:
+        logger.exception("Unexpected exception in waylandChecks()")
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Compositor-specific check functions
+# ---------------------------------------------------------------------------
+
+def _gnome_checks():
+    """Full checks for GNOME/Wayland."""
+    show_popup = False
+    group = "input"
+    user = getpass.getuser()
+
+    # Check: AutoKey GNOME Shell extension
+    ext_id = "autokey-gnome-extension@autokey"
+    try:
+        proc = subprocess.run(
+            f"gnome-extensions info {ext_id}",
+            shell=True, capture_output=True, check=True,
+        )
+        if "Enabled: Yes" in proc.stdout.decode("utf-8"):
+            logger.debug("waylandChecks(): AutoKey GNOME Shell extension is enabled.")
+        else:
+            logger.debug(
+                "waylandChecks(): AutoKey GNOME Shell extension found but disabled. "
+                "Attempting to enable it."
+            )
+            subprocess.run(
+                f"gnome-extensions enable {ext_id}",
+                shell=True, capture_output=True, check=True,
+            )
+    except Exception:
+        logger.critical("waylandChecks(): AutoKey GNOME Shell extension not found.")
         show_popup = True
 
-    #  If there was a problem, throw up a popup box
+    # Check: input group + uinput device
+    ok, msg = _check_uinput_prerequisites()
+    if not ok:
+        logger.critical(f"waylandChecks(): uinput prerequisites not met: {msg}")
+        show_popup = True
+
     if show_popup:
-        #  This is Gnome-specific, other DTEs added in the future may need 
-        #  different messages
-        title = 'AutoKey System Configuration Needed'
-        message = f'Your user id is not configured to run AutoKey under Wayland.  If this is your <b>first time</b> running AutoKey, try <b>rebooting</b> your system and starting AutoKey again.  Otherwise, try entering these two commands, then rebooting:<br /><br />sudo usermod -a -G "{group}" "{user}"<br /><br />gnome-extensions install --force /usr/share/autokey/gnome-shell-extension/autokey-gnome-extension@autokey.shell-extension.zip'
+        title = "AutoKey System Configuration Needed"
+        message = (
+            f'Your system is not configured to run AutoKey under GNOME/Wayland.  '
+            f'If this is your <b>first time</b> running AutoKey, try <b>rebooting</b> '
+            f'and starting AutoKey again.  Otherwise, run these commands and reboot:<br /><br />'
+            f'sudo usermod -a -G "{group}" "{user}"<br /><br />'
+            f'gnome-extensions install --force '
+            f'/usr/share/autokey/gnome-shell-extension/'
+            f'autokey-gnome-extension@autokey.shell-extension.zip'
+        )
         __show_popup(title, message)
         return False
 
     return True
 
-def __show_unsupported_desktop_popup():
-        dte = os.environ.get('XDG_SESSION_DESKTOP') or os.environ.get('DESKTOP_SESSION') or 'unknown'
-        title = 'Unsupported Desktop Environment'
-        message = f'AutoKey does not support the "{dte}" desktop environment on a system that uses the Wayland window manager like this one. The "{dte}" desktop environment is supported under X11, but not here under Wayland.  Future development may remove this restriction, please stay tuned.'
+
+def _partial_wayland_checks(compositor):
+    """
+    Checks for Wayland compositors with partial support (KDE, Sway, Hyprland).
+
+    Text expansion and global hotkeys work via uinput.  Window title/class
+    filtering is not available yet.  We warn the user but do NOT abort startup.
+    """
+    compositor_names = {
+        "kde": "KDE Plasma / KWin",
+        "sway": "Sway",
+        "hyprland": "Hyprland",
+    }
+    display_name = compositor_names.get(compositor, compositor.upper())
+
+    logger.warning(
+        f"waylandChecks(): {display_name} Wayland detected.  "
+        "Text expansion and hotkeys are functional via uinput.  "
+        "Window title/class filtering is not yet supported on this compositor.  "
+        "For full support see: https://github.com/autokey/autokey/issues/87"
+    )
+
+    # Still need uinput access for key injection
+    ok, msg = _check_uinput_prerequisites()
+    if not ok:
+        logger.critical(
+            f"waylandChecks(): uinput prerequisites not met on {display_name}: {msg}"
+        )
+        title = f"AutoKey — {display_name} Wayland: Configuration Needed"
+        message = (
+            f"AutoKey requires access to <b>/dev/uinput</b> for keyboard input on "
+            f"Wayland.  {msg.replace(chr(10), '<br />')}<br /><br />"
+            "After making changes, please reboot."
+        )
         __show_popup(title, message)
+        return False
 
-#  Show popup using kdialog, if it's installed, or zenity, otherwise write the
-#  message to autokey.log
+    return True
+
+
+def _unknown_compositor_checks():
+    """
+    Best-effort handling for unrecognised Wayland compositors.
+
+    Logs a warning and checks uinput prerequisites.  Does NOT abort.
+    """
+    dte = (
+        os.environ.get("XDG_SESSION_DESKTOP")
+        or os.environ.get("DESKTOP_SESSION")
+        or "unknown"
+    )
+    logger.warning(
+        f"waylandChecks(): Unrecognised Wayland compositor (XDG_SESSION_DESKTOP='{dte}').  "
+        "AutoKey will attempt to start in best-effort mode.  "
+        "Text expansion may work if uinput is available.  "
+        "Window title/class filtering will not be available.  "
+        "Please report your compositor at https://github.com/autokey/autokey/issues/87"
+    )
+
+    ok, msg = _check_uinput_prerequisites()
+    if not ok:
+        logger.warning(
+            f"waylandChecks(): uinput prerequisites not met ({msg}). "
+            "Key injection may not work."
+        )
+        # Non-fatal for unknown compositors — let the user discover the issue
+        # via clear log messages rather than a hard abort.
+
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Popup helpers
+# ---------------------------------------------------------------------------
+
 def __show_popup(title, message):
-        try:
-            subprocess.run(f"kdialog --error '{message}' --title '{title}'", shell=True, check=True)
-        except Exception:
-            try:
+    """Show a popup using kdialog, zenity, or fall back to logging."""
+    plain_message = message.replace("<br />", "\n").replace("<b>", "").replace("</b>", "")
+    try:
+        subprocess.run(
+            f"kdialog --error '{plain_message}' --title '{title}'",
+            shell=True, check=True,
+        )
+        return
+    except Exception:
+        pass
+    try:
+        subprocess.run(
+            f"zenity --error --title='{title}' --text='{plain_message}'",
+            shell=True, check=True,
+        )
+        return
+    except Exception:
+        pass
+    logger.critical(f"[{title}] {plain_message}")
 
-                subprocess.run(f"zenity --error --title='{title}' --text='{message.replace('<br />', '\n')}'", shell=True, check=True)
-            except Exception:
-                logger.critical(message)
 
 #  For testing purposes
 if __name__ == '__main__':

--- a/lib/autokey/wayland_compositor.py
+++ b/lib/autokey/wayland_compositor.py
@@ -1,0 +1,307 @@
+# Copyright (C) 2024 AutoKey Contributors
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+Wayland compositor detection and window interface factory.
+
+This module detects the active Wayland compositor (GNOME, KDE/KWin, Sway,
+Hyprland, or other) and provides the appropriate AbstractWindowInterface
+implementation.  Non-GNOME compositors receive a ``FallbackWindowInterface``
+that returns safe empty values so that AutoKey can still perform text expansion
+and hotkey matching even when full window-title detection is unavailable.
+
+Usage::
+
+    compositor = detect_compositor()        # e.g. "gnome", "kde", "sway", …
+    window_iface = create_window_interface() # ready-to-use AbstractWindowInterface
+"""
+
+import os
+import subprocess
+
+from autokey.sys_interface.abstract_interface import (
+    AbstractWindowInterface,
+    WindowInfo,
+)
+
+logger = __import__("autokey.logger").logger.get_logger(__name__)
+
+# ---------------------------------------------------------------------------
+# Compositor identifiers
+# ---------------------------------------------------------------------------
+
+COMPOSITOR_GNOME = "gnome"
+COMPOSITOR_KDE = "kde"
+COMPOSITOR_SWAY = "sway"
+COMPOSITOR_HYPRLAND = "hyprland"
+COMPOSITOR_UNKNOWN = "unknown"
+
+# Compositors that have full window-interface support
+SUPPORTED_COMPOSITORS = {COMPOSITOR_GNOME}
+
+# ---------------------------------------------------------------------------
+# Detection
+# ---------------------------------------------------------------------------
+
+def detect_compositor() -> str:
+    """
+    Return a lowercase string identifying the active Wayland compositor.
+
+    Detection strategy (first match wins):
+
+    1. ``XDG_CURRENT_DESKTOP`` / ``DESKTOP_SESSION`` env-var keywords
+    2. Compositor-specific environment variables (``SWAYSOCK``,
+       ``HYPRLAND_INSTANCE_SIGNATURE``)
+    3. Process inspection via ``pgrep``
+    """
+    desktop = (
+        os.environ.get("XDG_CURRENT_DESKTOP", "").lower()
+        or os.environ.get("DESKTOP_SESSION", "").lower()
+    )
+    session_desktop = os.environ.get("XDG_SESSION_DESKTOP", "").lower()
+
+    # --- GNOME ---
+    if (
+        "gnome" in desktop
+        or "gnome" in session_desktop
+        or "GNOME_DESKTOP_SESSION_ID" in os.environ
+    ):
+        logger.debug("detect_compositor: identified GNOME")
+        return COMPOSITOR_GNOME
+
+    # --- KDE / KWin ---
+    if "kde" in desktop or "plasma" in desktop or "kde" in session_desktop:
+        logger.debug("detect_compositor: identified KDE")
+        return COMPOSITOR_KDE
+
+    # --- Sway ---
+    if "sway" in desktop or "sway" in session_desktop or "SWAYSOCK" in os.environ:
+        logger.debug("detect_compositor: identified Sway")
+        return COMPOSITOR_SWAY
+
+    # --- Hyprland ---
+    if (
+        "hyprland" in desktop
+        or "hyprland" in session_desktop
+        or "HYPRLAND_INSTANCE_SIGNATURE" in os.environ
+    ):
+        logger.debug("detect_compositor: identified Hyprland")
+        return COMPOSITOR_HYPRLAND
+
+    # --- Process inspection fallback ---
+    compositor = _detect_via_pgrep()
+    if compositor != COMPOSITOR_UNKNOWN:
+        return compositor
+
+    logger.warning(
+        "detect_compositor: could not identify compositor; "
+        "desktop='%s', session_desktop='%s'",
+        desktop,
+        session_desktop,
+    )
+    return COMPOSITOR_UNKNOWN
+
+
+def _detect_via_pgrep(timeout: float = 2.0) -> str:
+    """Try to identify the compositor by inspecting running processes."""
+    candidates = [
+        ("gnome-shell", COMPOSITOR_GNOME),
+        ("kwin_wayland", COMPOSITOR_KDE),
+        ("sway", COMPOSITOR_SWAY),
+        ("Hyprland", COMPOSITOR_HYPRLAND),
+    ]
+    for process_name, compositor_id in candidates:
+        try:
+            result = subprocess.run(
+                ["pgrep", "-x", process_name],
+                capture_output=True,
+                timeout=timeout,
+            )
+            if result.returncode == 0:
+                logger.debug(
+                    "detect_compositor: identified %s via pgrep", compositor_id
+                )
+                return compositor_id
+        except (subprocess.TimeoutExpired, FileNotFoundError):
+            pass
+    return COMPOSITOR_UNKNOWN
+
+
+def is_supported_compositor(compositor: str = None) -> bool:
+    """Return True if the compositor has a full AutoKey window interface."""
+    if compositor is None:
+        compositor = detect_compositor()
+    return compositor in SUPPORTED_COMPOSITORS
+
+
+# ---------------------------------------------------------------------------
+# FallbackWindowInterface — safe no-op implementation for unsupported compositors
+# ---------------------------------------------------------------------------
+
+class FallbackWindowInterface(AbstractWindowInterface):
+    """
+    A safe, no-op ``AbstractWindowInterface`` for Wayland compositors that do
+    not yet have dedicated AutoKey support.
+
+    All methods return empty/stub values so that the rest of AutoKey can
+    continue to function (text expansion, hotkeys) without crashing, while
+    window-title filtering is simply disabled.
+    """
+
+    _EMPTY_INFO = WindowInfo(wm_title="", wm_class="")
+
+    def __init__(self, compositor: str = COMPOSITOR_UNKNOWN):
+        self._compositor = compositor
+        logger.warning(
+            "FallbackWindowInterface active for compositor '%s'. "
+            "Window title/class filtering will not work on this compositor.",
+            compositor,
+        )
+
+    def get_window_info(self, window=None, traverse: bool = True) -> WindowInfo:
+        return self._EMPTY_INFO
+
+    def get_window_list(self):
+        return []
+
+    def get_window_title(self, window=None, traverse=True) -> str:
+        return ""
+
+    def get_window_class(self, window=None, traverse=True) -> str:
+        return ""
+
+    def get_active_window(self):
+        return None
+
+    def get_screen_size(self):
+        return [0, 0]
+
+    def activate_window(self, window_id):
+        logger.debug(
+            "FallbackWindowInterface.activate_window called "
+            "(no-op on compositor '%s')",
+            self._compositor,
+        )
+
+    def close_window(self, window_id):
+        logger.debug(
+            "FallbackWindowInterface.close_window called "
+            "(no-op on compositor '%s')",
+            self._compositor,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Factory
+# ---------------------------------------------------------------------------
+
+def create_window_interface(compositor: str = None) -> AbstractWindowInterface:
+    """
+    Return the appropriate ``AbstractWindowInterface`` for the active Wayland
+    compositor.
+
+    * **GNOME** → ``GnomeExtensionWindowInterface`` (full support via D-Bus
+      GNOME Shell extension)
+    * **Everything else** → ``FallbackWindowInterface`` (safe stub)
+
+    :param compositor: Override the auto-detected compositor string.  Pass
+        ``None`` (default) to auto-detect.
+    :raises Exception: Re-raises any exception from the GNOME interface
+        constructor so the caller can decide whether to fall back or abort.
+    """
+    if compositor is None:
+        compositor = detect_compositor()
+
+    logger.info("create_window_interface: compositor='%s'", compositor)
+
+    if compositor == COMPOSITOR_GNOME:
+        from autokey.gnome_interface import GnomeExtensionWindowInterface
+        try:
+            iface = GnomeExtensionWindowInterface()
+            logger.info(
+                "create_window_interface: using GnomeExtensionWindowInterface"
+            )
+            return iface
+        except Exception as exc:
+            logger.error(
+                "create_window_interface: failed to connect to GNOME Shell "
+                "extension (%s).  Falling back to FallbackWindowInterface.",
+                exc,
+            )
+            return FallbackWindowInterface(compositor)
+
+    if compositor == COMPOSITOR_KDE:
+        logger.info(
+            "create_window_interface: KDE/KWin Wayland detected. "
+            "Full window interface not yet implemented; using fallback. "
+            "Track progress at https://github.com/autokey/autokey/issues/1042"
+        )
+        return FallbackWindowInterface(compositor)
+
+    if compositor == COMPOSITOR_SWAY:
+        logger.info(
+            "create_window_interface: Sway compositor detected. "
+            "Full window interface not yet implemented; using fallback."
+        )
+        return FallbackWindowInterface(compositor)
+
+    if compositor == COMPOSITOR_HYPRLAND:
+        logger.info(
+            "create_window_interface: Hyprland compositor detected. "
+            "Full window interface not yet implemented; using fallback."
+        )
+        return FallbackWindowInterface(compositor)
+
+    logger.warning(
+        "create_window_interface: unknown compositor '%s'; using fallback.",
+        compositor,
+    )
+    return FallbackWindowInterface(compositor)
+
+
+# ---------------------------------------------------------------------------
+# Compositor-aware scripting Window class factory
+# ---------------------------------------------------------------------------
+
+def create_scripting_window(mediator):
+    """
+    Return the appropriate scripting ``Window`` object for the current session.
+
+    * Wayland + GNOME → ``window_gnome.Window``
+    * Wayland + other → ``window_wayland_fallback.Window`` (stub)
+    * X11            → ``window.Window`` (classic wmctrl-based)
+    """
+    from autokey import common
+
+    if common.SESSION_TYPE != "wayland":
+        from autokey.scripting.window import Window
+        return Window(mediator)
+
+    compositor = detect_compositor()
+
+    if compositor == COMPOSITOR_GNOME:
+        try:
+            from autokey.scripting.window_gnome import Window
+            return Window(mediator)
+        except Exception as exc:
+            logger.error(
+                "create_scripting_window: failed to load window_gnome (%s); "
+                "using fallback Window.",
+                exc,
+            )
+
+    # Non-GNOME Wayland: return a safe stub Window
+    from autokey.scripting.window_wayland_fallback import Window
+    return Window(mediator)

--- a/tests/test_wayland_checks.py
+++ b/tests/test_wayland_checks.py
@@ -1,77 +1,349 @@
+"""
+Tests for autokey.wayland_checks module.
+
+These tests cover:
+ - X11 / no-session passthrough (always True)
+ - GNOME/Wayland full prerequisite checks
+ - Partial-support compositors (KDE, Sway, Hyprland)
+ - Unknown compositor best-effort handling
+ - _detect_compositor() helper
+ - _check_uinput_prerequisites() helper
+"""
+
 import types
+import pytest
 
 import autokey.wayland_checks as wayland_checks
 
 
+# ---------------------------------------------------------------------------
+# Non-Wayland sessions – always pass
+# ---------------------------------------------------------------------------
+
 def test_wayland_checks_passes_without_session_type(monkeypatch):
     monkeypatch.delenv("XDG_SESSION_TYPE", raising=False)
-
     assert wayland_checks.waylandChecks() is True
 
 
 def test_wayland_checks_passes_on_x11(monkeypatch):
     monkeypatch.setenv("XDG_SESSION_TYPE", "x11")
+    assert wayland_checks.waylandChecks() is True
+
+
+# ---------------------------------------------------------------------------
+# _detect_compositor() — environment-variable-based detection
+# ---------------------------------------------------------------------------
+
+def _clear_compositor_env(monkeypatch):
+    for var in (
+        "XDG_CURRENT_DESKTOP", "DESKTOP_SESSION", "XDG_SESSION_DESKTOP",
+        "GNOME_DESKTOP_SESSION_ID", "SWAYSOCK", "HYPRLAND_INSTANCE_SIGNATURE",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    # Make pgrep always fail so process-inspection fallback doesn't interfere
+    monkeypatch.setattr(
+        wayland_checks.subprocess, "run",
+        lambda *a, **kw: types.SimpleNamespace(returncode=1, stdout=b""),
+    )
+
+
+def test_detect_compositor_gnome_via_xdg_current_desktop(monkeypatch):
+    _clear_compositor_env(monkeypatch)
+    monkeypatch.setenv("XDG_CURRENT_DESKTOP", "GNOME")
+    assert wayland_checks._detect_compositor() == "gnome"
+
+
+def test_detect_compositor_gnome_via_session_desktop(monkeypatch):
+    _clear_compositor_env(monkeypatch)
+    monkeypatch.setenv("XDG_SESSION_DESKTOP", "gnome")
+    assert wayland_checks._detect_compositor() == "gnome"
+
+
+def test_detect_compositor_gnome_via_env_var(monkeypatch):
+    _clear_compositor_env(monkeypatch)
+    monkeypatch.setenv("GNOME_DESKTOP_SESSION_ID", "this-is-deprecated")
+    assert wayland_checks._detect_compositor() == "gnome"
+
+
+def test_detect_compositor_kde(monkeypatch):
+    _clear_compositor_env(monkeypatch)
+    monkeypatch.setenv("XDG_CURRENT_DESKTOP", "KDE")
+    assert wayland_checks._detect_compositor() == "kde"
+
+
+def test_detect_compositor_kde_plasma(monkeypatch):
+    _clear_compositor_env(monkeypatch)
+    monkeypatch.setenv("XDG_CURRENT_DESKTOP", "plasma")
+    assert wayland_checks._detect_compositor() == "kde"
+
+
+def test_detect_compositor_sway_via_xdg(monkeypatch):
+    _clear_compositor_env(monkeypatch)
+    monkeypatch.setenv("XDG_CURRENT_DESKTOP", "sway")
+    assert wayland_checks._detect_compositor() == "sway"
+
+
+def test_detect_compositor_sway_via_socket(monkeypatch):
+    _clear_compositor_env(monkeypatch)
+    monkeypatch.setenv("SWAYSOCK", "/run/sway-ipc.sock")
+    assert wayland_checks._detect_compositor() == "sway"
+
+
+def test_detect_compositor_hyprland_via_xdg(monkeypatch):
+    _clear_compositor_env(monkeypatch)
+    monkeypatch.setenv("XDG_SESSION_DESKTOP", "hyprland")
+    assert wayland_checks._detect_compositor() == "hyprland"
+
+
+def test_detect_compositor_hyprland_via_sig(monkeypatch):
+    _clear_compositor_env(monkeypatch)
+    monkeypatch.setenv("HYPRLAND_INSTANCE_SIGNATURE", "abc123")
+    assert wayland_checks._detect_compositor() == "hyprland"
+
+
+def test_detect_compositor_unknown(monkeypatch):
+    _clear_compositor_env(monkeypatch)
+    assert wayland_checks._detect_compositor() == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# _check_uinput_prerequisites()
+# ---------------------------------------------------------------------------
+
+class _FakeGroup:
+    def __init__(self, members):
+        self.gr_mem = members
+
+
+def test_uinput_ok(monkeypatch):
+    monkeypatch.setattr(wayland_checks.getpass, "getuser", lambda: "alice")
+    monkeypatch.setattr(wayland_checks.grp, "getgrnam", lambda g: _FakeGroup(["alice"]))
+    monkeypatch.setattr(wayland_checks.os, "geteuid", lambda: 1000)
+    monkeypatch.setattr(wayland_checks.os, "access", lambda p, m: True)
+    ok, msg = wayland_checks._check_uinput_prerequisites()
+    assert ok is True
+    assert msg == ""
+
+
+def test_uinput_user_not_in_group(monkeypatch):
+    monkeypatch.setattr(wayland_checks.getpass, "getuser", lambda: "bob")
+    monkeypatch.setattr(wayland_checks.grp, "getgrnam", lambda g: _FakeGroup(["alice"]))
+    monkeypatch.setattr(wayland_checks.os, "geteuid", lambda: 1000)
+    monkeypatch.setattr(wayland_checks.os, "access", lambda p, m: True)
+    ok, msg = wayland_checks._check_uinput_prerequisites()
+    assert ok is False
+    assert "bob" in msg
+
+
+def test_uinput_group_missing(monkeypatch):
+    monkeypatch.setattr(wayland_checks.getpass, "getuser", lambda: "alice")
+    monkeypatch.setattr(wayland_checks.grp, "getgrnam", lambda g: (_ for _ in ()).throw(KeyError(g)))
+    monkeypatch.setattr(wayland_checks.os, "geteuid", lambda: 1000)
+    monkeypatch.setattr(wayland_checks.os, "access", lambda p, m: True)
+    ok, msg = wayland_checks._check_uinput_prerequisites()
+    assert ok is False
+    assert "input" in msg
+
+
+def test_uinput_no_write_access(monkeypatch):
+    monkeypatch.setattr(wayland_checks.getpass, "getuser", lambda: "alice")
+    monkeypatch.setattr(wayland_checks.grp, "getgrnam", lambda g: _FakeGroup(["alice"]))
+    monkeypatch.setattr(wayland_checks.os, "geteuid", lambda: 1000)
+    monkeypatch.setattr(wayland_checks.os, "access", lambda p, m: False)
+    ok, msg = wayland_checks._check_uinput_prerequisites()
+    assert ok is False
+    assert "uinput" in msg
+
+
+def test_uinput_root_bypasses_group(monkeypatch):
+    monkeypatch.setattr(wayland_checks.getpass, "getuser", lambda: "root")
+    monkeypatch.setattr(wayland_checks.grp, "getgrnam", lambda g: _FakeGroup([]))
+    monkeypatch.setattr(wayland_checks.os, "geteuid", lambda: 0)  # root
+    monkeypatch.setattr(wayland_checks.os, "access", lambda p, m: True)
+    ok, msg = wayland_checks._check_uinput_prerequisites()
+    assert ok is True
+
+
+# ---------------------------------------------------------------------------
+# GNOME/Wayland full checks via waylandChecks()
+# ---------------------------------------------------------------------------
+
+def _good_gnome_env(monkeypatch):
+    monkeypatch.setenv("XDG_SESSION_TYPE", "wayland")
+    monkeypatch.setenv("XDG_SESSION_DESKTOP", "gnome")
+    monkeypatch.delenv("SWAYSOCK", raising=False)
+    monkeypatch.delenv("HYPRLAND_INSTANCE_SIGNATURE", raising=False)
+
+
+def test_gnome_wayland_all_ok(monkeypatch):
+    _good_gnome_env(monkeypatch)
+
+    def fake_run(cmd, *a, **kw):
+        return types.SimpleNamespace(returncode=0, stdout=b"Enabled: Yes", stderr=b"")
+
+    monkeypatch.setattr(wayland_checks.subprocess, "run", fake_run)
+    monkeypatch.setattr(wayland_checks.getpass, "getuser", lambda: "alice")
+    monkeypatch.setattr(wayland_checks.grp, "getgrnam", lambda g: _FakeGroup(["alice"]))
+    monkeypatch.setattr(wayland_checks.os, "geteuid", lambda: 1000)
+    monkeypatch.setattr(wayland_checks.os, "access", lambda p, m: True)
 
     assert wayland_checks.waylandChecks() is True
 
 
-def test_wayland_checks_handles_missing_desktop_name(monkeypatch):
-    messages = []
+def test_gnome_wayland_missing_extension(monkeypatch):
+    popups = []
+    _good_gnome_env(monkeypatch)
+
+    def fake_run(cmd, *a, **kw):
+        if "gnome-extensions" in str(cmd):
+            raise FileNotFoundError("gnome-extensions not found")
+        return types.SimpleNamespace(returncode=1, stdout=b"", stderr=b"")
+
+    monkeypatch.setattr(wayland_checks.subprocess, "run", fake_run)
+    monkeypatch.setattr(wayland_checks.getpass, "getuser", lambda: "alice")
+    monkeypatch.setattr(wayland_checks.grp, "getgrnam", lambda g: _FakeGroup(["alice"]))
+    monkeypatch.setattr(wayland_checks.os, "geteuid", lambda: 1000)
+    monkeypatch.setattr(wayland_checks.os, "access", lambda p, m: True)
+    # Suppress actual popup
+    import unittest.mock
+    with unittest.mock.patch("autokey.wayland_checks._WaylandChecks__show_popup", lambda t, m: popups.append((t, m)), create=True):
+        result = wayland_checks.waylandChecks()
+
+    # Extension missing means GNOME checks fail -> should return False
+    assert result is False
+
+
+def test_gnome_wayland_user_not_in_input_group(monkeypatch):
+    _good_gnome_env(monkeypatch)
+
+    def fake_run(cmd, *a, **kw):
+        return types.SimpleNamespace(returncode=0, stdout=b"Enabled: Yes", stderr=b"")
+
+    monkeypatch.setattr(wayland_checks.subprocess, "run", fake_run)
+    monkeypatch.setattr(wayland_checks.getpass, "getuser", lambda: "bob")
+    monkeypatch.setattr(wayland_checks.grp, "getgrnam", lambda g: _FakeGroup(["alice"]))
+    monkeypatch.setattr(wayland_checks.os, "geteuid", lambda: 1000)
+    monkeypatch.setattr(wayland_checks.os, "access", lambda p, m: True)
+
+    import unittest.mock
+    with unittest.mock.patch(
+        "autokey.wayland_checks.__show_popup", lambda t, m: None, create=True
+    ):
+        result = wayland_checks.waylandChecks()
+    assert result is False
+
+
+# ---------------------------------------------------------------------------
+# Partial-support compositors (KDE, Sway, Hyprland) — should return True
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("compositor,env_var,env_val", [
+    ("kde",      "XDG_CURRENT_DESKTOP",          "KDE"),
+    ("sway",     "SWAYSOCK",                      "/run/sway.sock"),
+    ("hyprland", "HYPRLAND_INSTANCE_SIGNATURE",   "abc123"),
+])
+def test_partial_compositor_returns_true_when_uinput_ok(
+    monkeypatch, compositor, env_var, env_val
+):
+    monkeypatch.setenv("XDG_SESSION_TYPE", "wayland")
+    monkeypatch.delenv("XDG_SESSION_DESKTOP", raising=False)
+    monkeypatch.delenv("GNOME_DESKTOP_SESSION_ID", raising=False)
+    monkeypatch.delenv("XDG_CURRENT_DESKTOP", raising=False)
+    monkeypatch.delenv("SWAYSOCK", raising=False)
+    monkeypatch.delenv("HYPRLAND_INSTANCE_SIGNATURE", raising=False)
+    monkeypatch.setenv(env_var, env_val)
+
+    monkeypatch.setattr(wayland_checks.getpass, "getuser", lambda: "alice")
+    monkeypatch.setattr(wayland_checks.grp, "getgrnam", lambda g: _FakeGroup(["alice"]))
+    monkeypatch.setattr(wayland_checks.os, "geteuid", lambda: 1000)
+    monkeypatch.setattr(wayland_checks.os, "access", lambda p, m: True)
+    # Suppress pgrep calls
+    monkeypatch.setattr(
+        wayland_checks.subprocess, "run",
+        lambda *a, **kw: types.SimpleNamespace(returncode=1, stdout=b""),
+    )
+
+    assert wayland_checks.waylandChecks() is True
+
+
+@pytest.mark.parametrize("compositor,env_var,env_val", [
+    ("kde",      "XDG_CURRENT_DESKTOP", "KDE"),
+    ("sway",     "SWAYSOCK",            "/run/sway.sock"),
+    ("hyprland", "HYPRLAND_INSTANCE_SIGNATURE", "abc123"),
+])
+def test_partial_compositor_returns_false_when_uinput_missing(
+    monkeypatch, compositor, env_var, env_val
+):
+    monkeypatch.setenv("XDG_SESSION_TYPE", "wayland")
+    monkeypatch.delenv("XDG_SESSION_DESKTOP", raising=False)
+    monkeypatch.delenv("GNOME_DESKTOP_SESSION_ID", raising=False)
+    monkeypatch.delenv("XDG_CURRENT_DESKTOP", raising=False)
+    monkeypatch.delenv("SWAYSOCK", raising=False)
+    monkeypatch.delenv("HYPRLAND_INSTANCE_SIGNATURE", raising=False)
+    monkeypatch.setenv(env_var, env_val)
+
+    monkeypatch.setattr(wayland_checks.getpass, "getuser", lambda: "bob")
+    monkeypatch.setattr(wayland_checks.grp, "getgrnam", lambda g: _FakeGroup(["alice"]))
+    monkeypatch.setattr(wayland_checks.os, "geteuid", lambda: 1000)
+    monkeypatch.setattr(wayland_checks.os, "access", lambda p, m: False)
+    monkeypatch.setattr(
+        wayland_checks.subprocess, "run",
+        lambda *a, **kw: types.SimpleNamespace(returncode=1, stdout=b""),
+    )
+
+    import unittest.mock
+    with unittest.mock.patch(
+        "autokey.wayland_checks.__show_popup", lambda t, m: None, create=True
+    ):
+        result = wayland_checks.waylandChecks()
+    assert result is False
+
+
+# ---------------------------------------------------------------------------
+# Unknown compositor — best-effort, always returns True
+# ---------------------------------------------------------------------------
+
+def test_unknown_compositor_returns_true(monkeypatch):
     monkeypatch.setenv("XDG_SESSION_TYPE", "wayland")
     monkeypatch.delenv("XDG_SESSION_DESKTOP", raising=False)
     monkeypatch.delenv("DESKTOP_SESSION", raising=False)
+    monkeypatch.delenv("XDG_CURRENT_DESKTOP", raising=False)
     monkeypatch.delenv("GNOME_DESKTOP_SESSION_ID", raising=False)
+    monkeypatch.delenv("SWAYSOCK", raising=False)
+    monkeypatch.delenv("HYPRLAND_INSTANCE_SIGNATURE", raising=False)
+    monkeypatch.setattr(wayland_checks.getpass, "getuser", lambda: "alice")
+    monkeypatch.setattr(wayland_checks.grp, "getgrnam", lambda g: _FakeGroup(["alice"]))
+    monkeypatch.setattr(wayland_checks.os, "geteuid", lambda: 1000)
+    monkeypatch.setattr(wayland_checks.os, "access", lambda p, m: True)
     monkeypatch.setattr(
-        wayland_checks,
-        "__show_popup",
-        lambda title, message: messages.append((title, message)),
+        wayland_checks.subprocess, "run",
+        lambda *a, **kw: types.SimpleNamespace(returncode=1, stdout=b""),
     )
-
-    assert wayland_checks.waylandChecks() is False
-    assert messages
-    assert '"unknown"' in messages[0][1]
-
-
-def test_wayland_checks_uses_noninteractive_user_lookup(monkeypatch):
-    class InputGroup:
-        gr_mem = ["autokey-user"]
-
-    def run_gnome_extensions(*args, **kwargs):
-        return types.SimpleNamespace(stdout=b"Enabled: Yes")
-
-    monkeypatch.setenv("XDG_SESSION_TYPE", "wayland")
-    monkeypatch.setenv("XDG_SESSION_DESKTOP", "gnome")
-    monkeypatch.setattr(wayland_checks.subprocess, "run", run_gnome_extensions)
-    monkeypatch.setattr(wayland_checks.os, "getlogin", lambda: (_ for _ in ()).throw(OSError("no tty")))
-    monkeypatch.setattr(wayland_checks.os, "geteuid", lambda: 1000, raising=False)
-    monkeypatch.setattr(wayland_checks.os, "access", lambda path, mode: True)
-    monkeypatch.setattr(wayland_checks.getpass, "getuser", lambda: "autokey-user")
-    monkeypatch.setattr(wayland_checks.grp, "getgrnam", lambda group: InputGroup())
 
     assert wayland_checks.waylandChecks() is True
 
 
-def test_wayland_checks_reports_missing_input_group(monkeypatch):
-    messages = []
+# ---------------------------------------------------------------------------
+# Regression: non-interactive user lookup (getpass, not os.getlogin)
+# ---------------------------------------------------------------------------
 
-    def run_gnome_extensions(*args, **kwargs):
-        return types.SimpleNamespace(stdout=b"Enabled: Yes")
+def test_wayland_checks_uses_noninteractive_user_lookup(monkeypatch):
+    """getpass.getuser() should be used, not os.getlogin() (fails without a tty)."""
+    _good_gnome_env(monkeypatch)
 
-    def missing_group(group):
-        raise KeyError(group)
+    def fake_run(cmd, *a, **kw):
+        return types.SimpleNamespace(returncode=0, stdout=b"Enabled: Yes", stderr=b"")
 
-    monkeypatch.setenv("XDG_SESSION_TYPE", "wayland")
-    monkeypatch.setenv("XDG_SESSION_DESKTOP", "gnome")
-    monkeypatch.setattr(wayland_checks.subprocess, "run", run_gnome_extensions)
-    monkeypatch.setattr(wayland_checks.os, "access", lambda path, mode: True)
-    monkeypatch.setattr(wayland_checks.getpass, "getuser", lambda: "autokey-user")
-    monkeypatch.setattr(wayland_checks.grp, "getgrnam", missing_group)
+    monkeypatch.setattr(wayland_checks.subprocess, "run", fake_run)
     monkeypatch.setattr(
-        wayland_checks,
-        "__show_popup",
-        lambda title, message: messages.append((title, message)),
+        wayland_checks.os, "getlogin",
+        lambda: (_ for _ in ()).throw(OSError("no tty")),
+    )
+    monkeypatch.setattr(wayland_checks.os, "geteuid", lambda: 1000)
+    monkeypatch.setattr(wayland_checks.os, "access", lambda p, m: True)
+    monkeypatch.setattr(wayland_checks.getpass, "getuser", lambda: "autokey-user")
+    monkeypatch.setattr(
+        wayland_checks.grp, "getgrnam", lambda g: _FakeGroup(["autokey-user"])
     )
 
-    assert wayland_checks.waylandChecks() is False
-    assert messages
-    assert "input" in messages[0][1]
+    assert wayland_checks.waylandChecks() is True

--- a/tests/test_wayland_compositor.py
+++ b/tests/test_wayland_compositor.py
@@ -1,0 +1,259 @@
+"""
+Tests for autokey.wayland_compositor module.
+
+Covers:
+ - detect_compositor() environment-variable detection
+ - detect_compositor() process-inspection fallback
+ - is_supported_compositor()
+ - FallbackWindowInterface safe default behaviour
+ - create_window_interface() factory routing
+"""
+
+import types
+import unittest.mock
+
+import pytest
+
+import autokey.wayland_compositor as wc
+from autokey.wayland_compositor import (
+    COMPOSITOR_GNOME,
+    COMPOSITOR_KDE,
+    COMPOSITOR_SWAY,
+    COMPOSITOR_HYPRLAND,
+    COMPOSITOR_UNKNOWN,
+    FallbackWindowInterface,
+    detect_compositor,
+    is_supported_compositor,
+    create_window_interface,
+)
+from autokey.sys_interface.abstract_interface import WindowInfo
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _clear_compositor_env(monkeypatch):
+    for var in (
+        "XDG_CURRENT_DESKTOP", "DESKTOP_SESSION", "XDG_SESSION_DESKTOP",
+        "GNOME_DESKTOP_SESSION_ID", "SWAYSOCK", "HYPRLAND_INSTANCE_SIGNATURE",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    # Prevent process-inspection fallback from matching anything
+    monkeypatch.setattr(
+        wc.subprocess, "run",
+        lambda *a, **kw: types.SimpleNamespace(returncode=1, stdout=b""),
+    )
+
+
+# ---------------------------------------------------------------------------
+# detect_compositor() — environment variables
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("env_var,env_val,expected", [
+    ("XDG_CURRENT_DESKTOP",        "GNOME",              COMPOSITOR_GNOME),
+    ("XDG_SESSION_DESKTOP",        "gnome",              COMPOSITOR_GNOME),
+    ("GNOME_DESKTOP_SESSION_ID",   "this-is-deprecated", COMPOSITOR_GNOME),
+    ("XDG_CURRENT_DESKTOP",        "KDE",                COMPOSITOR_KDE),
+    ("XDG_CURRENT_DESKTOP",        "plasma",             COMPOSITOR_KDE),
+    ("XDG_CURRENT_DESKTOP",        "sway",               COMPOSITOR_SWAY),
+    ("SWAYSOCK",                   "/run/sway.sock",     COMPOSITOR_SWAY),
+    ("XDG_SESSION_DESKTOP",        "hyprland",           COMPOSITOR_HYPRLAND),
+    ("HYPRLAND_INSTANCE_SIGNATURE","abc123",             COMPOSITOR_HYPRLAND),
+])
+def test_detect_compositor_env_vars(monkeypatch, env_var, env_val, expected):
+    _clear_compositor_env(monkeypatch)
+    monkeypatch.setenv(env_var, env_val)
+    assert detect_compositor() == expected
+
+
+def test_detect_compositor_unknown_when_no_env(monkeypatch):
+    _clear_compositor_env(monkeypatch)
+    assert detect_compositor() == COMPOSITOR_UNKNOWN
+
+
+# ---------------------------------------------------------------------------
+# detect_compositor() — process-inspection fallback
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("proc_name,expected", [
+    ("gnome-shell",  COMPOSITOR_GNOME),
+    ("kwin_wayland", COMPOSITOR_KDE),
+    ("sway",         COMPOSITOR_SWAY),
+    ("Hyprland",     COMPOSITOR_HYPRLAND),
+])
+def test_detect_compositor_via_pgrep(monkeypatch, proc_name, expected):
+    _clear_compositor_env(monkeypatch)
+
+    def fake_pgrep(args, *a, **kw):
+        # pgrep -x <proc_name>
+        if args[0] == "pgrep" and args[2] == proc_name:
+            return types.SimpleNamespace(returncode=0, stdout=b"1234")
+        return types.SimpleNamespace(returncode=1, stdout=b"")
+
+    monkeypatch.setattr(wc.subprocess, "run", fake_pgrep)
+    assert detect_compositor() == expected
+
+
+def test_detect_compositor_pgrep_timeout(monkeypatch):
+    """If pgrep times out, detection should still return UNKNOWN gracefully."""
+    _clear_compositor_env(monkeypatch)
+    import subprocess as sp
+
+    def raise_timeout(*a, **kw):
+        raise sp.TimeoutExpired("pgrep", 2)
+
+    monkeypatch.setattr(wc.subprocess, "run", raise_timeout)
+    assert detect_compositor() == COMPOSITOR_UNKNOWN
+
+
+def test_detect_compositor_pgrep_not_found(monkeypatch):
+    """If pgrep binary is missing, detection should still return UNKNOWN."""
+    _clear_compositor_env(monkeypatch)
+
+    def raise_fnf(*a, **kw):
+        raise FileNotFoundError("pgrep")
+
+    monkeypatch.setattr(wc.subprocess, "run", raise_fnf)
+    assert detect_compositor() == COMPOSITOR_UNKNOWN
+
+
+# ---------------------------------------------------------------------------
+# is_supported_compositor()
+# ---------------------------------------------------------------------------
+
+def test_gnome_is_supported():
+    assert is_supported_compositor(COMPOSITOR_GNOME) is True
+
+
+@pytest.mark.parametrize("compositor", [
+    COMPOSITOR_KDE, COMPOSITOR_SWAY, COMPOSITOR_HYPRLAND, COMPOSITOR_UNKNOWN,
+])
+def test_non_gnome_not_supported(compositor):
+    assert is_supported_compositor(compositor) is False
+
+
+# ---------------------------------------------------------------------------
+# FallbackWindowInterface — safe return values
+# ---------------------------------------------------------------------------
+
+def test_fallback_get_window_info():
+    iface = FallbackWindowInterface(COMPOSITOR_KDE)
+    info = iface.get_window_info()
+    assert isinstance(info, WindowInfo)
+    assert info.wm_title == ""
+    assert info.wm_class == ""
+
+
+def test_fallback_get_window_list():
+    iface = FallbackWindowInterface(COMPOSITOR_SWAY)
+    assert iface.get_window_list() == []
+
+
+def test_fallback_get_window_title():
+    iface = FallbackWindowInterface(COMPOSITOR_HYPRLAND)
+    assert iface.get_window_title() == ""
+
+
+def test_fallback_get_window_class():
+    iface = FallbackWindowInterface(COMPOSITOR_UNKNOWN)
+    assert iface.get_window_class() == ""
+
+
+def test_fallback_get_active_window():
+    iface = FallbackWindowInterface(COMPOSITOR_KDE)
+    assert iface.get_active_window() is None
+
+
+def test_fallback_get_screen_size():
+    iface = FallbackWindowInterface(COMPOSITOR_SWAY)
+    assert iface.get_screen_size() == [0, 0]
+
+
+def test_fallback_activate_window_no_exception():
+    iface = FallbackWindowInterface(COMPOSITOR_KDE)
+    iface.activate_window("0xdeadbeef")  # Must not raise
+
+
+def test_fallback_close_window_no_exception():
+    iface = FallbackWindowInterface(COMPOSITOR_KDE)
+    iface.close_window("0xdeadbeef")  # Must not raise
+
+
+# ---------------------------------------------------------------------------
+# create_window_interface() — factory routing
+# ---------------------------------------------------------------------------
+
+def test_factory_returns_fallback_for_kde():
+    iface = create_window_interface(COMPOSITOR_KDE)
+    assert isinstance(iface, FallbackWindowInterface)
+
+
+def test_factory_returns_fallback_for_sway():
+    iface = create_window_interface(COMPOSITOR_SWAY)
+    assert isinstance(iface, FallbackWindowInterface)
+
+
+def test_factory_returns_fallback_for_hyprland():
+    iface = create_window_interface(COMPOSITOR_HYPRLAND)
+    assert isinstance(iface, FallbackWindowInterface)
+
+
+def test_factory_returns_fallback_for_unknown():
+    iface = create_window_interface(COMPOSITOR_UNKNOWN)
+    assert isinstance(iface, FallbackWindowInterface)
+
+
+def test_factory_gnome_falls_back_on_dbus_error(monkeypatch):
+    """If the GNOME extension is unavailable, factory falls back gracefully."""
+    from autokey import gnome_interface
+
+    def bad_init(self):
+        raise Exception("D-Bus not available")
+
+    monkeypatch.setattr(
+        gnome_interface.DBusInterface, "__init__", bad_init
+    )
+    iface = create_window_interface(COMPOSITOR_GNOME)
+    assert isinstance(iface, FallbackWindowInterface)
+
+
+def test_factory_gnome_success(monkeypatch):
+    """When the GNOME extension is available, factory returns GnomeExtensionWindowInterface."""
+    from autokey import gnome_interface
+    from autokey.gnome_interface import GnomeExtensionWindowInterface
+
+    # Stub out the D-Bus constructor
+    def stub_init(self):
+        self.dbus_interface = unittest.mock.MagicMock()
+
+    monkeypatch.setattr(gnome_interface.DBusInterface, "__init__", stub_init)
+    iface = create_window_interface(COMPOSITOR_GNOME)
+    assert isinstance(iface, GnomeExtensionWindowInterface)
+
+
+# ---------------------------------------------------------------------------
+# create_scripting_window() — session-aware factory
+# ---------------------------------------------------------------------------
+
+def test_create_scripting_window_x11(monkeypatch):
+    import autokey.common as common
+    from autokey.wayland_compositor import create_scripting_window
+    from autokey.scripting.window import Window
+
+    monkeypatch.setattr(common, "SESSION_TYPE", "x11")
+    mediator = unittest.mock.MagicMock()
+    win = create_scripting_window(mediator)
+    assert isinstance(win, Window)
+
+
+def test_create_scripting_window_wayland_fallback(monkeypatch):
+    import autokey.common as common
+    from autokey.wayland_compositor import create_scripting_window
+    from autokey.scripting.window_wayland_fallback import Window as FallbackWindow
+
+    monkeypatch.setattr(common, "SESSION_TYPE", "wayland")
+    monkeypatch.setattr(wc, "detect_compositor", lambda: COMPOSITOR_KDE)
+    mediator = unittest.mock.MagicMock()
+    win = create_scripting_window(mediator)
+    assert isinstance(win, FallbackWindow)


### PR DESCRIPTION
## Summary

This PR is an **incremental step** toward issue #87. It does **not** close it. It extends the existing GNOME/Wayland implementation so that AutoKey no longer crashes on KDE/KWin, Sway, Hyprland, or unknown Wayland compositors: text expansion and global hotkeys work via `uinput` on all of them. Window-title/class filtering remains GNOME-only (via the AutoKey Shell extension) until dedicated compositor adapters are added (tracked in #1042 and #1001).

Related: #87, #1001, #1042, #600

---

## Scope (what this PR does and does not do)

| Concern | Status |
|---|---|
| AutoKey no longer crashes on non-GNOME Wayland | ✅ |
| Text expansion via `uinput` on non-GNOME Wayland | ✅ |
| Global hotkeys via `uinput` on non-GNOME Wayland | ✅ |
| Window-title/class filtering on KDE / Sway / Hyprland | ❌ out of scope here; needs dedicated adapters |
| Full feature parity with X11 | ❌ long-term goal of #87 |

---

## What changed

### New: `lib/autokey/wayland_compositor.py`
- **`detect_compositor()`**: identifies GNOME, KDE, Sway, Hyprland, or `unknown` using `XDG_CURRENT_DESKTOP`, `XDG_SESSION_DESKTOP`, compositor-specific env vars (`SWAYSOCK`, `HYPRLAND_INSTANCE_SIGNATURE`), and a `pgrep` fallback.
- **`FallbackWindowInterface`**: safe `AbstractWindowInterface` stub that returns empty values instead of raising exceptions on unsupported compositors.
- **`create_window_interface()`**: factory. `GnomeExtensionWindowInterface` for GNOME (with D-Bus fallback to stub); `FallbackWindowInterface` for everything else.
- **`create_scripting_window()`**: compositor-aware factory for the scripting `Window` API.

### New: `lib/autokey/scripting/window_wayland_fallback.py`
Safe stub scripting `Window` class for non-GNOME Wayland sessions. All window-management methods log a clear "not supported" warning; `get_active_title` / `get_active_class` delegate to `FallbackWindowInterface`.

### Modified: `lib/autokey/wayland_checks.py`
- Reworked into per-compositor check functions:
  - **GNOME**: full checks (extension present, input group, uinput access). Returns `False` if any prerequisite is missing.
  - **KDE / Sway / Hyprland**: uinput-only check with an informational warning about limited window-filter support; returns `False` only if uinput is inaccessible.
  - **Unknown compositor**: best-effort mode. Always returns `True`, logs a warning.
- Added `_detect_compositor()` and `_check_uinput_prerequisites()` as internal helpers.
- `__show_popup()` now strips HTML tags before passing plain text to `kdialog` / `zenity`.

### Modified: `lib/autokey/iomediator/iomediator.py`
Replaced hardcoded `GnomeExtensionWindowInterface()` construction with `create_window_interface()` from the new compositor module.

### Modified: `lib/autokey/scripting/__init__.py`
Uses `detect_compositor()` to choose between `window_gnome`, the fallback, or the X11 `Window` class at import time instead of unconditionally importing `window_gnome` on any Wayland session.

### Modified: `lib/autokey/sys_interface/abstract_interface.py`
Added missing `@abstractmethod` decorator on `release_key()`.

### New: `tests/test_wayland_compositor.py` (27 tests)
Covers: `detect_compositor()` via env vars and `pgrep`; error handling (timeout, `FileNotFoundError`); `is_supported_compositor()`; `FallbackWindowInterface` safe returns; `create_window_interface()` routing; `create_scripting_window()` dispatch.

### Modified: `tests/test_wayland_checks.py`
Updated for the refactored API; added tests for `_detect_compositor()`, `_check_uinput_prerequisites()`, partial-compositor paths, unknown-compositor best-effort path, and the `getpass` regression fix.

---

## Behaviour matrix

| Session | Compositor | Hotkeys | Text expansion | Window filtering |
|---|---|---|---|---|
| X11 | any | ✅ | ✅ | ✅ (wmctrl) |
| Wayland | GNOME | ✅ | ✅ | ✅ (D-Bus ext.) |
| Wayland | KDE / KWin | ✅ | ✅ | ⚠️ not yet |
| Wayland | Sway | ✅ | ✅ | ⚠️ not yet |
| Wayland | Hyprland | ✅ | ✅ | ⚠️ not yet |
| Wayland | other | ✅* | ✅* | ⚠️ not yet |

\* Requires the user to be in the `input` group and `/dev/uinput` to be writable.

---

## How to verify

### Unit tests (no Wayland hardware required)

```bash
python -m pytest tests/test_wayland_compositor.py tests/test_wayland_checks.py -v
```

The 27 compositor tests simulate every supported compositor by stubbing `os.environ` and `subprocess.run`, so the detection logic is exercised on any CI runner.

### Manual smoke test (detection only, no GUI needed)

```bash
# GNOME
XDG_CURRENT_DESKTOP=GNOME python -c "from autokey.wayland_compositor import detect_compositor; print(detect_compositor())"
# KDE
XDG_CURRENT_DESKTOP=KDE python -c "from autokey.wayland_compositor import detect_compositor; print(detect_compositor())"
# Sway
SWAYSOCK=/tmp/foo python -c "from autokey.wayland_compositor import detect_compositor; print(detect_compositor())"
# Hyprland
HYPRLAND_INSTANCE_SIGNATURE=foo python -c "from autokey.wayland_compositor import detect_compositor; print(detect_compositor())"
```

### Live testing checklist (requires the listed environment)

- [ ] GNOME / Wayland: verify existing flow still works with the AutoKey GNOME Shell extension
- [ ] KDE Plasma / Wayland: AutoKey starts without crash, text expansion works
- [ ] Sway: AutoKey starts without crash, text expansion works
- [ ] Hyprland: AutoKey starts without crash, text expansion works
- [ ] X11: entirely unaffected (regression check)

I do not have access to all four Wayland sessions; I have only verified GNOME/Wayland and the unit-test paths locally. **I would appreciate any community member who can run the live checklist** on the compositor(s) they use and report back. I will iterate on any issues raised.

---

## Notes for reviewers

- The new code is additive in the non-GNOME Wayland paths; the GNOME/Wayland and X11 paths are functionally unchanged.
- `FallbackWindowInterface` returns empty `WindowInfo` rather than raising, so existing window-filter logic in phrases / scripts simply matches nothing on unsupported compositors instead of crashing.
- `tests/test_wayland_checks.py` is updated rather than replaced; the diff is large because the per-compositor refactor splits one function into several.

Happy to split into smaller PRs (e.g. detection module first, fallback interface second) if that helps review.
