### PR TITLE
Add referral section to issue-report form

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -239,7 +239,18 @@ body:
       render: bash
     validations:
       required: false
-  
+
+  # HOW DID YOU FIND THE AUTOKEY PROJECT?
+  - type: textarea
+    id: referral
+    attributes:
+      label: How did you find the AutoKey project?
+      description: >
+        If this is your first AutoKey pull request, please
+        describe how you found the AutoKey project.
+    validations:
+      required: false
+
   # ANYTHING ELSE?
   - type: textarea
     id: notes

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,7 @@ Other
 +++++
 - Add `show_recent_script_errors_dialog` to display errors with millisecond precision.
 - Add **Environment** as an issue type in the `bug.yml` file.
+- Add the **referral** section to `bug.yml` issue-report form.
 
 Version 0.96.0
 ============================


### PR DESCRIPTION
Add the **referral** section to the bottom of the `bug.yml` issue-report form so users can share how they found the **AutoKey** project.
