### PR TITLE
Cherry-pick update of bug.yml from master

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -239,7 +239,18 @@ body:
       render: bash
     validations:
       required: false
-  
+
+  # HOW DID YOU FIND THE AUTOKEY PROJECT?
+  - type: textarea
+    id: referral
+    attributes:
+      label: How did you find the AutoKey project?
+      description: >
+        If this is your first AutoKey pull request, please
+        describe how you found the AutoKey project.
+    validations:
+      required: false
+
   # ANYTHING ELSE?
   - type: textarea
     id: notes

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -115,6 +115,7 @@ Other changes
 - Pin **PyGObject** version in `setup.cfg` to ensure cross-version harmony.
 - Update the dependencies in the `apt-requirements.txt` file.
 - Fix typos and formatting and wording in the ``_README.txt` file.
+- Cherry-pick the the `bug.yml` file from **master** to get the update that added a referral question to the issue-report form.
 
 .. _its counterpart: https://github.com/autokey/autokey/blob/master/.github/ISSUE_TEMPLATE/config.yml
 .. _PEP 440: https://peps.python.org/pep-0440/


### PR DESCRIPTION
Cherry-pick the updated `bug.yml` file from the **master** branch that added the referral section to the issue-report form.
