### PR TITLE
fix #646: guard grab_keyboard against X.NONE integer focus

### DIFF
--- a/lib/autokey/interface.py
+++ b/lib/autokey/interface.py
@@ -346,7 +346,8 @@ class XInterfaceBase(threading.Thread, AbstractMouseInterface):
     @queue_method(queue)
     def grab_keyboard(self):
         focus = self.localDisplay.get_input_focus().focus
-        focus.grab_keyboard(True, X.GrabModeAsync, X.GrabModeAsync, X.CurrentTime)
+        if not isinstance(focus, int):
+            focus.grab_keyboard(True, X.GrabModeAsync, X.GrabModeAsync, X.CurrentTime)
         self.localDisplay.flush()
 
     @queue_method(queue)


### PR DESCRIPTION
/bounty

Fix #646

When no window has keyboard focus, `get_input_focus().focus` returns `X.NONE` (integer 0). Calling `grab_keyboard()` on an int causes `AttributeError`. This fix adds an `isinstance` check before the grab call.