### PR TITLE
feat: add Wayland detection and graceful handling (towards #87)

### DIFF
--- a/lib/autokey/UI_common_functions.py
+++ b/lib/autokey/UI_common_functions.py
@@ -27,6 +27,7 @@ qt_modules = ['PyQt5', 'PyQt5.QtGui', 'PyQt5.QtWidgets', 'PyQt5.QtCore',
 
 # wmctrl, xrandr are x11 specific programs.
 x11_programs = ['wmctrl', 'xrandr']
+wayland_programs = ['wl-copy', 'wl-paste']
 common_programs = ['ps']
 # Checking some of these appears to be redundant as some are provided by the same packages on my system but 
 # better safe than sorry.
@@ -120,6 +121,8 @@ def checkRequirements():
 
     if os.environ.get("XDG_SESSION_TYPE") == "x11":
         missing_programs = checkProgramImports(x11_programs)
+    elif os.environ.get("XDG_SESSION_TYPE") == "wayland":
+        missing_programs = checkProgramImports(wayland_programs)
 
     if common.USED_UI_TYPE == "QT":
         missing_programs = checkProgramImports(common_programs+qt_programs)

--- a/lib/autokey/autokey_app.py
+++ b/lib/autokey/autokey_app.py
@@ -30,7 +30,6 @@ import re
 
 import autokey.model.script
 from autokey import common
-from autokey.common import *
 
 from autokey import service, monitor
 
@@ -46,6 +45,41 @@ import autokey.wayland_checks as awc
 
 logger = get_logger(__name__)
 del get_logger
+
+AuthorData = NamedTuple("AuthorData", (("name", str), ("role", str), ("email", str)))
+AboutData = NamedTuple("AboutData", (
+    ("program_name", str),
+    ("version", str),
+    ("program_description", str),
+    ("license_text", str),
+    ("copyright_notice", str),
+    ("homepage_url", str),
+    ("bug_report_email", str),
+    ("author_list", Iterable[AuthorData])
+))
+
+COPYRIGHT = """(c) 2009-2012 Chris Dekter
+(c) 2014 GuoCi
+(c) 2017, 2018 Thomas Hess
+"""
+
+author_data = (
+    AuthorData("Thomas Hess", "PyKDE4 to PyQt5 port", "thomas.hess@udo.edu"),
+    AuthorData("GuoCi", "Python 3 port maintainer", "guociz@gmail.com"),
+    AuthorData("Chris Dekter", "Developer", "cdekter@gmail.com"),
+    AuthorData("Sam Peterson", "Original developer", "peabodyenator@gmail.com")
+)
+about_data = AboutData(
+   program_name="AutoKey",
+   version=common.VERSION,
+   program_description="Desktop automation utility",
+   license_text="GPL v3",  # TODO: load actual license text from disk somewhere
+   copyright_notice=COPYRIGHT,
+   homepage_url=common.HOMEPAGE,
+   bug_report_email=common.BUG_EMAIL,
+   author_list=author_data
+)
+
 
 class AutokeyApplication:
     """
@@ -82,7 +116,7 @@ class AutokeyApplication:
         if self.__verify_not_running():
             AutokeyApplication.create_lock_file()
             atexit.register(os.remove, common.LOCK_FILE)
-
+			
         self.__initialise_services()
         self.__add_user_code_dir_to_path()
         self.__create_DBus_service()

--- a/lib/autokey/common.py
+++ b/lib/autokey/common.py
@@ -24,6 +24,9 @@ XDG_CONFIG_HOME = os.environ.get('XDG_CONFIG_HOME', os.path.expanduser('~/.confi
 XDG_CACHE_HOME = os.environ.get('XDG_CACHE_HOME', os.path.expanduser('~/.cache'))
 XDG_DATA_HOME = os.environ.get('XDG_DATA_HOME', os.path.expanduser("~/.local/share"))
 SESSION_TYPE = os.environ.get("XDG_SESSION_TYPE")
+DESKTOP = os.environ.get('XDG_CURRENT_DESKTOP')
+if DESKTOP and DESKTOP.lower() in ('kde', 'plasma'):
+    DESKTOP = 'KDE'
 
 CONFIG_DIR = os.path.join(XDG_CONFIG_HOME, "autokey")
 RUN_DIR = os.path.join(os.environ.get('XDG_RUNTIME_DIR', XDG_CACHE_HOME), "autokey")
@@ -35,19 +38,21 @@ LOCK_FILE = os.path.join(RUN_DIR, "autokey.pid")
 
 APP_NAME = "autokey"
 CATALOG = ""
-VERSION = "0.97.0-beta.0"
-HOMEPAGE = "https://github.com/autokey/autokey"
+VERSION = "0.97.4"
+HOMEPAGE = "https://github.com/dlk3/autokey-wayland"
 AUTHOR = 'Chris Dekter'
 AUTHOR_EMAIL = 'cdekter@gmail.com'
-MAINTAINER = 'sebastiansam55'
-MAINTAINER_EMAIL = 'sebastiansam55@gmail.com'
-BUG_EMAIL = ""
+MAINTAINER = 'dlk3'
+MAINTAINER_EMAIL = 'dave@daveking.com'
+BUG_EMAIL = "autokey-wayland@fire.fundersclub.com"
 COPYRIGHT = """
+(c) 2008 Sam Peterson
 (c) 2009-2012 Chris Dekter
 (c) 2014 GuoCi
-(c) 2017, 2018 Thomas Hess
-(c) 2020, 2021 BlueDrink9
-(c) 2024 sebastiansam55
+(c) 2017-2018 Thomas Hess
+(c) 2020-2021 Silico Biomancer
+(c) 2024 Sam Sebastian
+(c) 2026 David King
 """
 
 AuthorData = NamedTuple("AuthorData", (("name", str), ("role", str), ("email", str)))
@@ -62,28 +67,42 @@ AboutData = NamedTuple("AboutData", (
     ("author_list", Iterable[AuthorData])
 ))
 author_data = (
-    AuthorData("Thomas Hess", "PyKDE4 to PyQt5 port", "thomas.hess@udo.edu"),
-    AuthorData("GuoCi", "Python 3 port maintainer", "guociz@gmail.com"),
-    AuthorData("Chris Dekter", "Developer", "cdekter@gmail.com"),
     AuthorData("Sam Peterson", "Original developer", "peabodyenator@gmail.com"),
-    AuthorData("Sam Sebastian", "Wayland port", "sebastiansam55@gmail.com")
+    AuthorData("Chris Dekter", "Developer", "cdekter@gmail.com"),
+    AuthorData("GuoCi", "Python 3 port maintainer", "guociz@gmail.com"),
+    AuthorData("Thomas Hess", "PyKDE4 to PyQt5 port", "thomas.hess@udo.edu"),
+    AuthorData("Silico Biomancer", "Developer", ""),
+    AuthorData("Sam Sebastian", "Wayland port", "sebastiansam55@gmail.com"),
+    AuthorData("David King", "Wayland enhancements", "dave@daveking.com")
 )
 about_data = AboutData(
-   program_name="AutoKey",
+   program_name="AutoKey for Wayland",
    version=VERSION,
    program_description="Desktop automation utility",
-   license_text="GPL v3",  # TODO: load actual license text from disk somewhere
+   license_text="""
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+""",
    copyright_notice=COPYRIGHT,
    homepage_url=HOMEPAGE,
    bug_report_email=BUG_EMAIL,
    author_list=author_data
 )
 
-
-FAQ_URL = "https://github.com/autokey/autokey/wiki/FAQ"
-API_URL = "https://autokey.github.io/"
-HELP_URL = "https://github.com/autokey/autokey/wiki/Troubleshooting"
-BUG_URL = HOMEPAGE + "/issues"
+FAQ_URL = 'https://autokey-wayland.readthedocs.io/en/latest/'
+HELP_URL = 'https://autokey-wayland.readthedocs.io/en/latest/'
+API_URL = HELP_URL + "/api.html"
+BUG_URL = "https://github.com/dlk3/autokey-wayland/issues"
 
 ICON_FILE = "autokey"
 ICON_FILE_NOTIFICATION = "autokey-status"
@@ -92,8 +111,19 @@ ICON_FILE_NOTIFICATION_ERROR = "autokey-status-error"
 
 # Set at the top of each entrypoint app
 USED_UI_TYPE = "headless"
-USING_QT = False
 
-# Share parsed command line arguments between modules, Namespace object content 
+# Share parsed command line arguments between modules, Namespace object content
 # set by argument_parser.py
 ARGS = None
+
+# A list of text strings that are the names of the keyboard and mouse devices
+# that we want to recognize automatically during system startup under Wayland.
+# There is no need to add names that include the words "keyboard" or "mouse" to
+# these lists.  AutoKey will recognize those without them being here.
+WAYLAND_KEYBOARD_DEVICE_LIST = (
+    'Logitech K270',
+    'Logitech K400'
+)
+WAYLAND_MOUSE_DEVICE_LIST = (
+    'Logitech MX Ergo'
+)

--- a/lib/autokey/configmanager/configmanager.py
+++ b/lib/autokey/configmanager/configmanager.py
@@ -363,21 +363,6 @@ class ConfigManager:
         for path in data["folders"]:
             yield path
 
-    def __load_folders(self, data):
-        for path in self.get_all_config_folder_paths(data):
-            f = autokey.model.folder.Folder("", path=path)
-            f.load()
-            logger.debug("Loading folder at '%s'", path)
-            self.folders.append(f)
-
-
-    def get_all_config_folder_paths(self, data):
-        for path in glob.glob(CONFIG_DEFAULT_FOLDER + "/*"):
-            if os.path.isdir(path):
-                yield path
-        for path in data["folders"]:
-            yield path
-
     def get_all_folders(self):
         out = []
         for folder in self.folders:

--- a/lib/autokey/configmanager/predefined_user_files.py
+++ b/lib/autokey/configmanager/predefined_user_files.py
@@ -123,7 +123,7 @@ sample_scripts_data = [
         trigger_modes=[],
         window_filter=None,
         show_in_tray_menu=False,
-        content="create_phrase_from_selection"),
+        content="create_phrase_from_selection"),        
     ItemData(
         name="Display window info",
         hotkey=None,
@@ -131,7 +131,15 @@ sample_scripts_data = [
         trigger_modes=[],
         window_filter=None,
         show_in_tray_menu=True,
-        content="display_window_info")
+        content="display_window_info"),
+    ItemData(
+        name="Unicode Strings In Scripts",
+        hotkey=None,
+        abbreviations=[],
+        trigger_modes=[],
+        window_filter=None,
+        show_in_tray_menu=True,
+        content="unicode_strings_in_scripts")
 ]
 
 

--- a/lib/autokey/gnome_interface.py
+++ b/lib/autokey/gnome_interface.py
@@ -1,3 +1,21 @@
+#  Copyright (C) 2023 Sam Sebastian
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#####################################################################
+
+
 import dbus
 import json
 from dbus.mainloop.glib import DBusGMainLoop
@@ -15,7 +33,7 @@ class DBusInterface:
 
         version = self.dbus_interface.CheckVersion()
         logger.debug("AutoKey Gnome Extension version: %s" % version)
-        if version == "0.1":
+        if version == "0.2":
             pass
         else:
             raise Exception("Incompatible version of AutoKey Gnome Extension")
@@ -32,6 +50,9 @@ class GnomeExtensionWindowInterface(DBusInterface, AbstractWindowInterface):
     def __init__(self):
         super().__init__()
 
+    def get_active_desktop_index(self):
+        return self._dbus_get_active_desktop_index()
+
     def get_window_list(self):
         return self._dbus_window_list()
 
@@ -39,7 +60,7 @@ class GnomeExtensionWindowInterface(DBusInterface, AbstractWindowInterface):
         x,y = self.dbus_interface.ScreenSize()
         return [int(x), int(y)]
 
-    def  get_active_window(self):
+    def get_active_window(self):
         return self._active_window()
 
     def get_window_info(self, window=None, traverse: bool=True) -> WindowInfo:
@@ -67,6 +88,45 @@ class GnomeExtensionWindowInterface(DBusInterface, AbstractWindowInterface):
 
     def activate_window(self, window_id):
         self._dbus_activate_window(window_id)
+        
+    def move_resize_window(self, window_id, x, y , width, height):
+        self._dbus_move_resize_window(window_id, x, y, width, height)
+
+    def get_screensize(self):
+        return self._dbus_get_screensize()
+
+    def move_to_workspace(self, window_id, workspace_number):
+        self._dbus_move_to_workspace(window_id, workspace_number)
+    
+    def switch_workspace(self, workspace_number):
+        self._dbus_switch_workspace(workspace_number)
+        
+    def get_properties(self, window_id):
+        return self._dbus_get_properties(window_id)
+        
+    def stick_window(self, window_id):
+        self._dbus_stick_window(window_id)
+        
+    def unstick_window(self, window_id):
+        self._dbus_unstick_window(window_id)
+        
+    def maximize_window(self, window_id, direction):
+        self._dbus_maximize_window(window_id, direction)
+        
+    def unmaximize_window(self, window_id, direction):
+        self._dbus_unmaximize_window(window_id, direction)
+        
+    def make_fullscreen_window(self, window_id):
+        self._dbus_make_fullscreen_window(window_id)
+        
+    def unmake_fullscreen_window(self, window_id):
+        self._dbus_unmake_fullscreen_window(window_id)
+        
+    def make_above_window(self, window_id):
+        self._dbus_make_above_window(window_id)
+        
+    def unmake_above_window(self, window_id):
+        self._dbus_unmake_above_window(window_id)
 
     def _active_window(self):
         #TODO probably can be done more efficiently with an additional dbus method in the gnome extension
@@ -102,7 +162,14 @@ class GnomeExtensionWindowInterface(DBusInterface, AbstractWindowInterface):
             'in_current_workspace': False
         }
         return empty_window
-            
+    
+    def _dbus_get_active_desktop_index(self):
+        try:
+            return self.dbus_interface.GetActiveWorkspaceIndex()
+        except dbus.exceptions.DBusException as e:
+            self.__init__() #reconnect to dbus
+            return self.dbus_interface.GetActiveWorkspaceIndex()
+                
     def _dbus_window_list(self):
         #TODO consider how/if error handling can be implemented
         try:
@@ -121,10 +188,17 @@ class GnomeExtensionWindowInterface(DBusInterface, AbstractWindowInterface):
 
     def _dbus_activate_window(self, window_id):
         try:
-            self.dbus_interface.Activate(window_id)
+            self.dbus_interface.Raise(window_id)
         except dbus.exceptions.DBusException as e:  
             self.__init__()
-            self.dbus_interface.Activate(window_id)
+            self.dbus_interface.Raise(window_id)
+
+    def _dbus_move_resize_window(self, window_id, x, y, width, height):
+        try:
+            self.dbus_interface.MoveResize(window_id, x, y, width, height)
+        except dbus.exceptions.DBusException as e:
+            self.__init__()
+            self.dbus_interface.MoveResize(window_id, x, y, width, height)
 
     def _dbus_move_window(self, window_id, x, y):
         try:
@@ -139,3 +213,87 @@ class GnomeExtensionWindowInterface(DBusInterface, AbstractWindowInterface):
         except dbus.exceptions.DBusException as e:
             self.__init__()
             self.dbus_interface.Resize(window_id, width, height)
+
+    def _dbus_move_to_workspace(self, window_id, workspace_number):
+        try:
+            self.dbus_interface.MoveToWorkspace(window_id, workspace_number)
+        except dbus.exceptions.DBusException as e:
+            self.__init__()
+            self.dbus_interface.MoveToWorkspace(window_id, workspace_number)
+
+    def _dbus_get_screensize(self):
+        try:
+            return self.dbus_interface.ScreenSize()
+        except dbus.exceptions.DBusException as e:
+            self.__init__()
+            return self.dbus_interface.ScreenSize()
+
+    def _dbus_switch_workspace(self, workspace_number):
+        try:
+            return self.dbus_interface.SwitchWorkspace(workspace_number)
+        except dbus.exceptions.DBusException as e:
+            self.__init__()
+            return self.dbus_interface.SwitchWorkspace(workspace_number)
+
+    def _dbus_get_properties(self, window_id):
+        try:
+            return json.loads(self.dbus_interface.Properties(window_id))
+        except dbus.exceptions.DBusException as e:
+            self.__init__()
+            return json.loads(self.dbus_interface.Properties(window_id))
+
+    def _dbus_stick_window(self, window_id):
+        try:
+            self.dbus_interface.Stick(window_id)
+        except dbus.exceptions.DBusException as e:
+            self.__init__()
+            self.dbus_interface.Stick(window_id)
+    
+    def _dbus_unstick_window(self, window_id):
+        try:
+            self.dbus_interface.UnStick(window_id)
+        except dbus.exceptions.DBusException as e:
+            self.__init__()
+            self.dbus_interface.UnStick(window_id)
+        
+    def _dbus_maximize_window(self, window_id, direction):
+        try:
+            self.dbus_interface.Maximize(window_id, direction)
+        except dbus.exceptions.DBusException as e:
+            self.__init__()
+            self.dbus_interface.Maximize(window_id, direction)
+        
+    def _dbus_unmaximize_window(self, window_id, direction):
+        try:
+            self.dbus_interface.UnMaximize(window_id, direction)
+        except dbus.exceptions.DBusException as e:
+            self.__init__()
+            self.dbus_interface.UnMaximize(window_id, direction)
+        
+    def _dbus_make_fullscreen_window(self, window_id):
+        try:
+            self.dbus_interface.MakeFullscreen(window_id)
+        except dbus.exceptions.DBusException as e:
+            self.__init__()
+            self.dbus_interface.MakeFullscreen(window_id)
+        
+    def _dbus_unmake_fullscreen_window(self, window_id):
+        try:
+            self.dbus_interface.UnMakeFullscreen(window_id)
+        except dbus.exceptions.DBusException as e:
+            self.__init__()
+            self.dbus_interface.UnMakeFullscreen(window_id)
+        
+    def _dbus_make_above_window(self, window_id):
+        try:
+            self.dbus_interface.MakeAbove(window_id)
+        except dbus.exceptions.DBusException as e:
+            self.__init__()
+            self.dbus_interface.MakeAbove(window_id)  
+                 
+    def _dbus_unmake_above_window(self, window_id):
+        try:
+            self.dbus_interface.UnMakeAbove(window_id)
+        except dbus.exceptions.DBusException as e:
+            self.__init__()
+            self.dbus_interface.UnMakeAbove(window_id)

--- a/lib/autokey/gtkapp.py
+++ b/lib/autokey/gtkapp.py
@@ -90,7 +90,12 @@ class Application(AutokeyApplication, AutokeyUIInterface):
         self.notifier.rebuild_menu()
 
     def path_created_or_modified(self, path):
-        UI_common.path_created_or_modified(self.configManager, self.configWindow, path)
+	#  @dlk3  Fix for issue #16.  Wrap this call to 
+        #  catch an exception, log and otherwise ignore it
+        try:
+            UI_common.path_created_or_modified(self.configManager, self.configWindow, path)
+        except Exception as e:
+            logger.exception("Unexpected error in gtkapp.path_created_or_modified, program continues: " + str(e))
 
     def path_removed(self, path):
         UI_common.path_removed(self.configManager, self.configWindow, path)

--- a/lib/autokey/gtkui/configwindow.py
+++ b/lib/autokey/gtkui/configwindow.py
@@ -1329,14 +1329,15 @@ class ConfigWindow:
     def on_show_about(self, widget, data=None):
         dlg = Gtk.AboutDialog()
         dlg.set_name("AutoKey")
-        dlg.set_comments(_("A desktop automation utility for Linux and X11."))
+        dlg.set_comments(_("A desktop automation utility for Linux, Wayland and X11."))
         dlg.set_version(common.VERSION)
         p = Gtk.IconTheme.get_default().load_icon(common.ICON_FILE, 100, 0)
         dlg.set_logo(p)
         dlg.set_website(common.HOMEPAGE)
-        dlg.set_authors(["GuoCi (Python 3 port maintainer) <guociz@gmail.com>",
-                         "Chris Dekter (Developer) <cdekter@gmail.com>",
-                         "Sam Peterson (Original developer) <peabodyenator@gmail.com>"])
+        authors_list = []
+        for author in common.author_data:
+            authors_list.append(f"{author.name} ({author.role}) <{author.email}>")
+        dlg.set_authors(authors_list)
         dlg.set_transient_for(self.ui)
         dlg.run()
         dlg.destroy()

--- a/lib/autokey/gtkui/settingsdialog.py
+++ b/lib/autokey/gtkui/settingsdialog.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 # Copyright (C) 2011 Chris Dekter
+# Copyright (C) 2026  David King <dave@daveking.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/autokey/interface.py
+++ b/lib/autokey/interface.py
@@ -346,7 +346,8 @@ class XInterfaceBase(threading.Thread, AbstractMouseInterface):
     @queue_method(queue)
     def grab_keyboard(self):
         focus = self.localDisplay.get_input_focus().focus
-        focus.grab_keyboard(True, X.GrabModeAsync, X.GrabModeAsync, X.CurrentTime)
+        if not isinstance(focus, int):
+            focus.grab_keyboard(True, X.GrabModeAsync, X.GrabModeAsync, X.CurrentTime)
         self.localDisplay.flush()
 
     @queue_method(queue)

--- a/lib/autokey/interface.py
+++ b/lib/autokey/interface.py
@@ -69,6 +69,8 @@ if common.USED_UI_TYPE == "GTK":
         HAS_ATSPI = False
 
 from Xlib import X, XK, display, error
+from autokey import wayland_checks
+import os
 try:
     from Xlib.ext import record, xtest
     HAS_RECORD = True
@@ -345,9 +347,10 @@ class XInterfaceBase(threading.Thread, AbstractMouseInterface):
 
     @queue_method(queue)
     def grab_keyboard(self):
+        if os.environ.get('XDG_SESSION_TYPE') == 'wayland':
+            return
         focus = self.localDisplay.get_input_focus().focus
-        if not isinstance(focus, int):
-            focus.grab_keyboard(True, X.GrabModeAsync, X.GrabModeAsync, X.CurrentTime)
+        focus.grab_keyboard(True, X.GrabModeAsync, X.GrabModeAsync, X.CurrentTime)
         self.localDisplay.flush()
 
     @queue_method(queue)

--- a/lib/autokey/iomediator/iomediator.py
+++ b/lib/autokey/iomediator/iomediator.py
@@ -22,7 +22,10 @@ import autokey
 from autokey import common
 from autokey.configmanager.configmanager import ConfigManager
 from autokey.configmanager.configmanager_constants import INTERFACE_TYPE
-from autokey.gnome_interface import GnomeExtensionWindowInterface
+if common.DESKTOP == 'KDE':
+    from autokey.kde_interface import KdeWindowInterface
+else:
+    from autokey.gnome_interface import GnomeExtensionWindowInterface
 from autokey.sys_interface.clipboard import Clipboard
 from autokey.model.phrase import SendMode
 
@@ -39,14 +42,14 @@ class IoMediator(threading.Thread):
     """
     The IoMediator is responsible for tracking the state of modifier keys and
     interfacing with the various Interface classes to obtain the correct
-    characters to pass to the expansion service. 
-    
+    characters to pass to the expansion service.
+
     This class must not store or maintain any configuration details.
     """
-    
+
     # List of targets interested in receiving keypress, hotkey and mouse events
     listeners = []
-    
+
     def __init__(self, service):
         threading.Thread.__init__(self, name="KeypressHandler-thread")
 
@@ -54,7 +57,7 @@ class IoMediator(threading.Thread):
         self.listeners.append(service)
         self.interfaceType = ConfigManager.SETTINGS[INTERFACE_TYPE]
         self.app = service.app
-        
+
         # Modifier tracking
         self.modifiers = {}
         for key in MODIFIERS:
@@ -70,8 +73,13 @@ class IoMediator(threading.Thread):
             pass
 
         if self.interfaceType == "uinput":
-            logger.debug("Using gnome extension window interface")
-            self.windowInterface = GnomeExtensionWindowInterface()
+            logger.debug(f'common.DESKTOP = {common.DESKTOP}')
+            if common.DESKTOP == 'KDE':
+                logger.debug("Using kde window interface")
+                self.windowInterface = KdeWindowInterface()
+            else:
+                logger.debug("Using gnome extension window interface")
+                self.windowInterface = GnomeExtensionWindowInterface()
         else:
             from autokey.interface import XWindowInterface
             self.windowInterface = XWindowInterface()
@@ -100,6 +108,12 @@ class IoMediator(threading.Thread):
 
 
     def shutdown(self):
+        #  If the windowInterface has a cancel method, call it.
+        #  KdeWindowInterface needs this to shutdown cleanly.
+        cancel_method = getattr(self.windowInterface, "cancel", None)
+        if callable(cancel_method):
+            logger.debug('windowInterface shutting down.')
+            self.windowInterface.cancel()
         logger.debug("IoMediator shutting down")
         self.interface.cancel()
         logger.debug("queue.put_nowait()")
@@ -124,7 +138,7 @@ class IoMediator(threading.Thread):
     def set_modifier_state(self, modifier, state):
         logger.debug("Set modifier %s to %r", modifier, state)
         self.modifiers[modifier] = state
-    
+
     def handle_modifier_down(self, modifier):
         """
         Updates the state of the given modifier key to 'pressed'.
@@ -139,7 +153,7 @@ class IoMediator(threading.Thread):
                 self.modifiers[modifier] = True
         else:
             self.modifiers[modifier] = True
-        
+
     def handle_modifier_up(self, modifier):
         """
         Updates the state of the given modifier key to 'released'.
@@ -151,17 +165,17 @@ class IoMediator(threading.Thread):
 
     def handle_keypress(self, key_code, window_info):
         """
-        Looks up the character for the given key code, applying any 
+        Looks up the character for the given key code, applying any
         modifiers currently in effect, and passes it to the expansion service.
         """
         self.queue.put_nowait((key_code, window_info))
-        
+
     def run(self):
         while True:
             key_code, window_info = self.queue.get()
             if key_code is None and window_info is None:
                 break
-            
+
             num_lock = self.modifiers[Key.NUMLOCK]
             modifiers = self._get_modifiers_on()
             shifted = self.modifiers[Key.CAPSLOCK] ^ self.modifiers[Key.SHIFT]
@@ -175,13 +189,13 @@ class IoMediator(threading.Thread):
                 target.handle_keypress(raw_key, modifiers, key, window_info)
 
             self.queue.task_done()
-            
+
     def handle_mouse_click(self, root_x, root_y, rel_x, rel_y, button, window_info):
         # We make a copy here because the wait_for... functions modify the listeners,
         # and we want this processing cycle to complete before changing what happens
         for target in self.listeners.copy():
             target.handle_mouseclick(root_x, root_y, rel_x, rel_y, button, window_info)
-        
+
     # Methods for expansion service ----
 
     def send_string(self, string: str):
@@ -193,7 +207,7 @@ class IoMediator(threading.Thread):
 
         string = string.replace('\n', "<enter>")
         string = string.replace('\t', "<tab>")
-        
+
         logger.debug("Send via event interface")
         self._clear_modifiers()
         IoMediator._send_string(string, self.interface)
@@ -247,7 +261,7 @@ class IoMediator(threading.Thread):
 
     def remove_string(self, string):
         backspaces = -1  # Start from -1 to discount the backspace already pressed by the user
-        
+
         for section in KEY_SPLIT_RE.split(string):
             if Key.is_key(section):
                 # TODO: Only a subset of keys defined in Key are printable, thus require a backspace.
@@ -288,11 +302,11 @@ class IoMediator(threading.Thread):
     def send_right(self, count):
         for _ in range(count):
             self.send_key(Key.RIGHT)
-    
+
     def send_up(self, count):
         """
         Sends the given number of up key presses.
-        """        
+        """
         for _ in range(count):
             self.send_key(Key.UP)
 
@@ -305,12 +319,12 @@ class IoMediator(threading.Thread):
 
     def flush(self):
         self.interface.flush()
-        
+
     # Utility methods ----
-    
+
     def _clear_modifiers(self):
         self.releasedModifiers = []
-        
+
         for modifier in list(self.modifiers.keys()):
             if self.modifiers[modifier] and modifier not in (Key.CAPSLOCK, Key.NUMLOCK):
                 self.releasedModifiers.append(modifier)
@@ -325,7 +339,7 @@ class IoMediator(threading.Thread):
         for modifier in HELD_MODIFIERS:
             if self.modifiers[modifier]:
                 modifiers.append(modifier)
-        
+
         modifiers.sort()
         return modifiers
 

--- a/lib/autokey/kde_interface.py
+++ b/lib/autokey/kde_interface.py
@@ -1,0 +1,627 @@
+#  Copyright (C) 2026 David King
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#####################################################################
+
+from gi.repository import GLib
+from pydbus import SessionBus
+import json
+import os
+import subprocess
+import tempfile
+import time
+import threading
+import glob
+import queue
+
+from autokey.sys_interface.abstract_interface import AbstractSysInterface, AbstractWindowInterface, WindowInfo, queue_method
+
+logger = __import__("autokey.logger").logger.get_logger(__name__)
+
+#  Toggle extra debug log messages useful for tracing
+VERBOSE=False
+
+#  The name of the KWinListener DBus service.
+DBUS_SERVICE_NAME='org.autokey.KWinListener'
+
+#  The definition for a DBus service that listens for a message from a
+#  KWin script.
+#
+#  The XML in the docstring in this class is NOT a comment, it is the
+#  DBus introspection detail that pydbus uses when it publishes this
+#  service.
+class KWinListener(object):
+    """
+        <node>
+            <interface name='org.autokey.KWinListener'>
+                <method name='Response'>
+                    <arg type='s' name='response' direction='in'/>
+                </method>
+                <method name='Signal'>
+                    <arg type='s' name='response' direction='in'/>
+                </method>
+                <method name='Shutdown'/>
+            </interface>
+        </node>
+    """
+    def __init__(self):
+        self.response_queue = queue.Queue()
+        self.signal_queue = queue.Queue()
+
+    def Response(self, message):
+        self.response_queue.put(message)
+        if VERBOSE:
+            logger.debug(f'KWinListener queued a Response message:\n{json.loads(message)}')
+        return True
+
+    def Signal(self, message):
+        self.signal_queue.put(message)
+        if VERBOSE:
+            logger.debug(f'KWinListener queued a Signal message:\n{json.loads(message)}')
+        return True
+
+    def Shutdown(self):
+        self.signal_queue.shutdown()
+        self.response_queue.shutdown()
+        loop.quit()
+        return True
+
+class KWinInterface():
+
+    def __init__(self, timeout=1):
+        self.timeout = timeout
+        self.response_cache = {}
+        self.signal_scripts = {}
+        self.signal_response_cache = {}
+
+        #  Write KDE version to debug log
+        try:
+            proc = subprocess.run(['plasmashell', '--version'], capture_output=True, check=True)
+            kde_version = proc.stdout.decode('utf-8').split(' ')[1].strip()
+            logger.debug(f'KDE Plasma version = {kde_version}')
+        except subprocess.CalledProcessError:
+            logger.exception('KDE Plasma version check failed')
+
+        #  Start the DBus service thread
+        self.loop = GLib.MainLoop()
+        self.dbus_thread = threading.Thread(target=self._dbus_service)
+        self.dbus_thread.start()
+
+        #  Delete any old script files from the tmp directory
+        fn_spec = os.path.join(tempfile.gettempdir(), 'autokey.kwin.script.*.js')
+        for fn in glob.glob(fn_spec):
+            os.unlink(fn)
+
+        #  Preload the KWin signal scripts
+        self._preload_signal_scripts()
+
+    #  Method that runs the DBus service in a seperate thread
+    def _dbus_service(self):
+        self.listener = KWinListener()
+        bus = SessionBus()
+        dbus_service = bus.publish(DBUS_SERVICE_NAME, self.listener)
+        self.loop.run()
+
+    #  Method to sutdown the DBus service thread and clean up KWin
+    #  scripts and their temp files
+    def cancel(self):
+        self.loop.quit()
+        self.dbus_thread.join()
+
+        #  Shut down the signal scripts
+        bus = SessionBus()
+        for script_name, script_id in self.signal_scripts.items():
+            obj = bus.get('org.kde.KWin', f'/Scripting/{script_id}')
+            obj.stop()
+
+        #  Erase the temporary script files
+        fn_spec = os.path.join(tempfile.gettempdir(), 'autokey.kwin.script.*.js')
+        for fn in glob.glob(fn_spec):
+            os.unlink(fn)
+
+    #  Method that loads a kwin_script into KWin.  Called by run() below.
+    def _load_script(self, kwin_script, response_expected=False):
+        if response_expected:
+            service_path = '/' + DBUS_SERVICE_NAME.replace('.','/')
+            kwin_script = kwin_script + f' callDBus("{DBUS_SERVICE_NAME}", "{service_path}", "{DBUS_SERVICE_NAME}", "Response", result);'
+
+        bus = SessionBus()
+        obj = bus.get('org.kde.KWin', '/Scripting')
+
+        #  Save the KWin script in a temporary file
+        (f, self.script_fn) = tempfile.mkstemp(prefix='autokey.kwin.script.', suffix='.js')
+        with open(self.script_fn, 'w') as script_file:
+            script_file.write(kwin_script)
+
+        #  Load the script file into KWin
+        return 'Script' + str(obj.loadScript(self.script_fn))
+
+    #  Method that loads the KWin signal scripts.  Called by __init__()
+    #  above.
+    def _preload_signal_scripts(self):
+        service_path = '/' + DBUS_SERVICE_NAME.replace('.','/')
+        self.signal_scripts = {
+            'get_active_window': """function send_active_window(client) {
+    result = ['get_active_window', [client, workspace.currentDesktop]];
+    callDBus("<service_name>", "<service_path>", "<service_name>", "Signal", JSON.stringify(result));
+}
+result = ['get_active_window', [workspace.activeWindow, workspace.currentDesktop]];
+callDBus("<service_name>", "<service_path>", "<service_name>", "Signal", JSON.stringify(result));
+workspace.windowActivated.connect(send_active_window);""".replace('<service_name>', DBUS_SERVICE_NAME).replace('<service_path>', service_path),
+
+            'get_active_desktop_index': """function send_active_window(previous_desktop) {
+    result = ['get_active_desktop_index', workspace.currentDesktop];
+    callDBus("<service_name>", "<service_path>", "<service_name>", "Signal", JSON.stringify(result));
+}
+result = ['get_active_desktop_index', workspace.currentDesktop];
+callDBus("<service_name>", "<service_path>", "<service_name>", "Signal", JSON.stringify(result));
+workspace.currentDesktopChanged.connect(send_active_window);""".replace('<service_name>', DBUS_SERVICE_NAME).replace('<service_path>', service_path)
+        }
+        bus = SessionBus()
+        for script_name, kwin_script in self.signal_scripts.items():
+            #  Save the KWin script in a temporary file
+            (f, fn) = tempfile.mkstemp(prefix=f'autokey.kwin.script.{script_name}.', suffix='.js')
+            with open(fn, 'w') as script_file:
+                script_file.write(kwin_script)
+
+            #  Load the script file into KWin
+            obj = bus.get('org.kde.KWin', '/Scripting')
+            script_id = 'Script' + str(obj.loadScript(fn))
+
+            #  Save the script id for later reference
+            self.signal_scripts[script_name] = script_id
+
+            #  Start the script
+            obj = bus.get('org.kde.KWin', f'/Scripting/{script_id}')
+            obj.run()
+
+    #  Method that runs a kwin_script
+    def run(self, kwin_script, script_name=None, response_expected=False):
+        #  If this is a KWin signal script, then it should have a cached
+        #  response.  Return that.
+        if script_name in self.signal_scripts:
+            #  Process the contents of the signal queue into the signal
+            #  response cache
+            try:
+                while True:
+                    response = json.loads(self.listener.signal_queue.get(block=False))
+                    if VERBOSE:
+                        logger.debug('Caching a response from the signal_queue for ' + response[0])
+                    self.signal_response_cache[response[0]] = response[1]
+            except queue.Empty:
+                #  Once the queue has been emptied, return the cached
+                #  response.
+                if script_name in self.signal_response_cache:
+                    if VERBOSE:
+                        logger.debug(f'Returning a cached response for {script_name}')
+                    return self.signal_response_cache[script_name]
+            logger.warning(f'The {script_name} KWin script should have a cached response and it does not, AutoKey will run the KWin script.')
+
+        #  Otherwise, run the script ...
+        script_id = self._load_script(kwin_script, response_expected=response_expected)
+        bus = SessionBus()
+        obj = bus.get('org.kde.KWin', f'/Scripting/{script_id}')
+        obj.run()
+
+        #  Read contents of queue, cache what we read, and return a live
+        #  result for the script that called us, or a cached result if
+        #  we timed out waiting for a reply to appear on the queue.
+        #  Timeout value is set when KWinInterface is instantiated.
+        reply = None
+        if response_expected:
+            try:
+                one_time_timeout = self.timeout
+                while True:
+                    item = json.loads(self.listener.response_queue.get(timeout=one_time_timeout))
+                    one_time_timeout = 0
+                    if VERBOSE:
+                        logger.debug('Caching a response from the response_queue for ' + item[0])
+                    #  Put a timestamp at the front of the result so we
+                    #  can tell how old it is.
+                    self.response_cache[item[0]] = [time.time(), item[1]]
+                    if item[0] == script_name:
+                        reply = item[1]
+            except queue.Empty:
+                if not reply:
+                    #  If this script is in the cache
+                    if script_name in self.response_cache:
+                        #  and it's result isn't too old
+                        if time.time() - self.response_cache[script_name][0] < 30:
+                            if VERBOSE:
+                                logger.debug(f'Returning a cached response for {script_name}')
+                            reply = self.response_cache[script_name][1]
+            if not reply:
+                logger.warning(f'Timed out waiting for a response from the {script_name} KWin script and there is no recent cached result to reply with.  Returning "None"')
+
+        #  Remove the script from Kwin
+        obj.stop()
+        os.unlink(self.script_fn)
+
+        return reply
+
+class KdeMouseInterface():
+    def __init__(self):
+        super().__init__()
+
+    def mouse_location(self):
+        """
+        Returns the x/y coordinates of the mouse pointer
+
+        :return: [x, y]
+        :rtype: list
+        """
+        kwin_script = 'let result = JSON.stringify(["mouse_location", workspace.cursorPos]);'
+        result = self.mediator.windowInterface.kwin.run(kwin_script, script_name='mouse_location', response_expected=True)
+        if result:
+            return [result['x'], result['y']]
+
+class KdeWindowInterface(AbstractWindowInterface):
+    def __init__(self):
+        super().__init__()
+        self.kwin = KWinInterface()
+
+    def cancel(self):
+        self.kwin.cancel()
+
+    def get_window_info(self, window=None, traverse: bool=True) -> WindowInfo:
+        """
+        Ask KWin for title and class of the currently focused window.
+
+        :return: (wm_title, wm_class)
+        :rtype: WindowInfo
+        """
+        result = self.get_active_window()
+        if result:
+            return WindowInfo(wm_title=result['wm_title'], wm_class=result['wm_class'])
+        else:
+            return WindowInfo(wm_title='unknown', wm_class='unknown')
+
+    def get_window_list(self):
+        """
+        Ask KWin for a list of all the windows on the desktop
+
+        :return: An array containing information about each window
+        :rtype: list of dictionaries
+        """
+        kwin_script = 'let result = JSON.stringify(["get_window_list", [workspace.windowList(), workspace.currentDesktop]]);'
+        result = self.kwin.run(kwin_script, script_name='get_window_list', response_expected=True)
+        window_list = []
+        if result:
+            for window in result[0]:
+                if not window['desktopWindow'] and len(window['desktops']) > 0 and 'Xwayland Video Bridge' not in window['caption']:
+                    in_current_workspace = False
+                    for desktop in window['desktops']:
+                        if desktop['id'] == result[1]['id']:
+                            in_current_workspace = True
+                            break
+                    window_list.append({
+                        'wm_class': window['resourceClass'],
+                        'wm_class_instance': window['resourceClass'],
+                        'wm_title': window['caption'],
+                        'workspace': window['desktops'][0]['x11DesktopNumber'] - 1,
+                        'desktop': window['desktops'][0]['id'],
+                        'pid': window['pid'],
+                        'id': window['internalId'],
+                        'frame_type': None,
+                        'window_type': window['windowType'],
+                        'width': int(window['width']),
+                        'height': int(window['height']),
+                        'x': window['x'],
+                        'y': window['y'],
+                        'focus': window['active'],
+                        'in_current_workspace': in_current_workspace
+                    })
+        return window_list
+
+    def get_window_title(self, window=None, traverse=True) -> str:
+        """
+        Returns the window title of the currently focused window.
+
+        :return: window title
+        :rtype: string
+        """
+        result = self.get_active_window()
+        if result:
+            return result['wm_title']
+
+    def get_window_class(self, window=None, traverse=True) -> str:
+        """
+        Returns the window class of the currently focused window.
+
+        :return: window class
+        :rtype: string
+        """
+        result = self.get_active_window()
+        if result:
+            return result['wm_class']
+
+    def get_screen_size(self):
+        """
+        Returns the width and height of the display
+
+        :return: [width, height]
+        :rtype: list
+        """
+        kwin_script = 'let result = JSON.stringify(["get_screen_size", workspace.activeScreen.geometry]);'
+        result = self.kwin.run(kwin_script, script_name='get_screen_size', response_expected=True)
+        if result:
+           return [result['width'], result['height']]
+
+    ####################################################################
+    #  The following methods support the window API
+    ####################################################################
+
+    def get_active_window(self):
+        """
+        Ask KWin for the details for the currently focused window
+
+        :return: A dictionary containing information a window
+        :rtype: dictionary
+        """
+        kwin_script = 'let result = JSON.stringify(["get_active_window", [workspace.activeWindow, workspace.currentDesktop]]);'
+        result = self.kwin.run(kwin_script, script_name='get_active_window', response_expected=True)
+        if result and result[0]:
+            window = result[0]
+            in_current_workspace = False
+            for desktop in window['desktops']:
+                if desktop['id'] == result[1]['id']:
+                    in_current_workspace = True
+                    break
+            active_window = {
+                'wm_class': window['resourceClass'],
+                'wm_class_instance': window['resourceClass'],
+                'wm_title': window['caption'],
+                'workspace': window['desktops'][0]['x11DesktopNumber'] - 1,
+                'desktop': window['desktops'][0]['id'],
+                'pid': window['pid'],
+                'id': window['internalId'],
+                'frame_type': None,
+                'window_type': window['windowType'],
+                'width': int(window['width']),
+                'height': int(window['height']),
+                'x': window['x'],
+                'y': window['y'],
+                'focus': window['active'],
+                'in_current_workspace': in_current_workspace
+            }
+        else:
+            logger.error(f"Unable to determine the active window.")
+            active_window = {
+                'wm_class': '',
+                'wm_class_instance': '',
+                'wm_title': '',
+                'workspace': None,
+                'desktop': None,
+                'pid': None,
+                'id': None,
+                'frame_type': None,
+                'window_type': None,
+                'width': None,
+                'height': None,
+                'x': None,
+                'y': None,
+                'focus': False,
+                'in_current_workspace': False
+            }
+        return active_window
+
+    def get_active_desktop_index(self):
+        kwin_script = 'let result = JSON.stringify(["get_active_window", workspace.currentDesktop]);'
+        result = self.kwin.run(kwin_script, script_name='get_active_desktop_index', response_expected=True)
+        if result:
+           return result['x11DesktopNumber'] - 1
+
+    def close_window(self, window_id):
+        kwin_script = """const w = workspace.windowList().find((w) => w.internalId == '<window_id>');
+if (w) {
+    w.closeWindow();
+}""".replace('<window_id>', window_id)
+        self.kwin.run(kwin_script)
+
+    def activate_window(self, window_id):
+        if not window_id:
+            logger.error('valid window_id not provided for activate_window()')
+            return
+        kwin_script = """const w = workspace.windowList().find((w) => w.internalId == '<window_id>');
+if (w) {
+    workspace.activeWindow = w;
+}""".replace('<window_id>', window_id)
+        self.kwin.run(kwin_script)
+
+    def move_resize_window(self, window_id, x, y , width, height):
+        if not window_id:
+            logger.error('valid window_id not provided for move_resize_window()')
+            return
+        kwin_script = """const w = workspace.windowList().find((w) => w.internalId == '<window_id>');
+if (w) {
+    let obj = Object.assign({}, w.frameGeometry);
+    obj.x = <x>;
+    obj.y = <y>;
+    obj.width = <width>;
+    obj.height = <height>;
+    w.frameGeometry = obj;
+}""".replace('<window_id>', window_id)
+        kwin_script = kwin_script.replace('<x>', str(x))
+        kwin_script = kwin_script.replace('<y>', str(y))
+        kwin_script = kwin_script.replace('<width>', str(width))
+        kwin_script = kwin_script.replace('<height>', str(height))
+        self.kwin.run(kwin_script)
+
+    def move_to_workspace(self, window_id, workspace_number):
+        if not window_id:
+            logger.error('invalid window_id specified for move_to_workspace()')
+            return
+        try:
+            workspace_number = int(workspace_number)
+        except:
+            logger.error(f'invalid workspace_number specified for move_to_workspace(): "{workspace_number}"')
+            return
+        kwin_script = """let d = workspace.desktops.find((d) => d.x11DesktopNumber == <workspace_number>);
+if (d) {
+    const w = workspace.windowList().find((w) => w.internalId == '<window_id>');
+    if (w) {
+        w.desktops = [d];
+    }
+}""".replace('<window_id>', window_id)
+        kwin_script = kwin_script.replace('<workspace_number>', str(workspace_number + 1))
+        self.kwin.run(kwin_script)
+
+    def switch_workspace(self, workspace_number):
+        try:
+            workspace_number = int(workspace_number)
+        except:
+            logger.error(f'invalid workspace_number specified for switch_workspace(): "{workspace_number}"')
+            return
+        kwin_script = """let d = workspace.desktops.find((d) => d.x11DesktopNumber == <workspace_number>);
+if (d) {
+    workspace.currentDesktop = d;
+}""".replace('<workspace_number>', str(workspace_number + 1))
+        self.kwin.run(kwin_script)
+
+    def get_properties(self, window_id):
+        if not window_id:
+            logger.error('valid window_id not provided for get_properties()')
+            return
+        kwin_script = """let w = workspace.windowList().find((w) => w.internalId == '<window_id>');
+if (w) {
+    let s = workspace.clientArea(KWin.MaximizeArea, w);
+    result = JSON.stringify(['get_properties', [w, s]]);
+} else {
+    result = JSON.stringify(['get_properties', [null, null]]);
+}""".replace('<window_id>', window_id)
+        result = self.kwin.run(kwin_script, script_name='get_properties', response_expected=True)
+        if result:
+            (window, screen) = result
+            return {
+                'is_above': window['keepAbove'],
+                'is_fullscreen': window['fullScreen'],
+                'is_hidden': window['hidden'],
+                'is_maximized_vert': (window['height'] == screen['height']),
+                'is_maximized_horz': (window['width'] == screen['width']),
+                'is_shaded': window['shade'],
+                'is_skip_pager': window['skipPager'],
+                'is_skip_taskbar': window['skipTaskbar']
+            }
+        else:
+            return
+
+    def set_properties(window_id, prop, value):
+        kwin_script = """const w = workspace.windowList().find((w) => w.internalId == '<window_id>');
+if (w) {
+    w.<property> = <value>;
+}""".replace('<window_id>', window_id);
+        kwin_script = kwin_script.replace('<property>', prop)
+        kwin_script = kwin_script.replace('<value>', 'true' if value else 'false')
+        self.kwin.run(kwin_script)
+
+    def stick_window(self, window_id):
+        logger.warning('stick_window() not implemented for KDE/Wayland.  The sticky property is not exposed in the KWin script API.')
+        return
+
+    def unstick_window(self, window_id):
+        logger.warning('unstick_window() not implemented for KDE/Wayland:  The sticky property is not exposed in the KWin script API.')
+        return
+
+    def maximize_window(self, window_id, direction):
+        #  direction:
+        #    1 - horizontal
+        #    2 - vertical
+        #    3 - both
+        if not window_id:
+            logger.error('valid window_id not provided for maximize_window()')
+            return
+        kwin_script = """const w = workspace.windowList().find((w) => w.internalId == '<window_id>');
+if (w) {
+    w.setMaximize(<maximize>);
+}""".replace('<window_id>', window_id)
+        if direction == 1:
+            kwin_script = kwin_script.replace('<maximize>', 'false, true')
+        elif direction == 2:
+            kwin_script = kwin_script.replace('<maximize>', 'true, false')
+        elif direction == 3:
+            kwin_script = kwin_script.replace('<maximize>', 'true, true')
+        else:
+            logger.warning('maximize_window(direction) called with invalid value.  Must be 1 for horizontal, 2 for vertical, or 3 for both.')
+            return
+        self.kwin.run(kwin_script)
+
+    def unmaximize_window(self, window_id, direction):
+        #  direction:
+        #    1 - horizontal
+        #    2 - vertical
+        #    3 - both
+        if not window_id:
+            logger.error('valid window_id not provided for unmaximize_window()')
+            return
+        if direction not in [1,2,3]:
+            logger.warning('unmaximize_window(direction) called with invalid value.  Must be 1 for horizontal, 2 for vertical, or 3 for both.')
+            return
+        kwin_script = """const direction = <direction>;
+const w = workspace.windowList().find((w) => w.internalId == '<window_id>');
+if (w) {
+    const s = workspace.clientArea(KWin.MaximizeArea, w);
+    vert = (w.height > s.height);
+    horz = (w.width == s.width);
+    if (direction == 1) {
+        w.setMaximize(vert, false);
+    } else if (direction == 2){
+        w.setMaximize(false, horz);
+    } else if (direction == 3) {
+        w.setMaximize(false, false);
+    }
+}""".replace('<window_id>', window_id)
+        kwin_script = kwin_script.replace('<direction>', str(direction))
+        self.kwin.run(kwin_script)
+
+    def make_fullscreen_window(self, window_id):
+        if not window_id:
+            logger.error('valid window_id not provided for make_fullscreen_window()')
+            return
+        kwin_script = """const w = workspace.windowList().find((w) => w.internalId == '<window_id>');
+if (w) {
+    w.fullScreen = true;
+}""".replace('<window_id>', window_id)
+        self.kwin.run(kwin_script)
+
+    def unmake_fullscreen_window(self, window_id):
+        if not window_id:
+            logger.error('valid window_id not provided for unmake_fullscreen_window()')
+            return
+        kwin_script = """const w = workspace.windowList().find((w) => w.internalId == '<window_id>');
+if (w) {
+    w.fullScreen = false;
+}""".replace('<window_id>', window_id)
+        self.kwin.run(kwin_script)
+
+    def make_above_window(self, window_id):
+        if not window_id:
+            logger.error('valid window_id not provided make_above_window()')
+            return
+        kwin_script = """const w = workspace.windowList().find((w) => w.internalId == '<window_id>');
+if (w) {
+    w.keepAbove = true;
+}""".replace('<window_id>', window_id)
+        self.kwin.run(kwin_script)
+
+    def unmake_above_window(self, window_id):
+        if not window_id:
+            logger.error('valid window_id not provided for unmake_above_window()')
+            return
+        kwin_script = """const w = workspace.windowList().find((w) => w.internalId == '<window_id>');
+if (w) {
+    w.keepAbove = false;
+}""".replace('<window_id>', window_id)
+        self.kwin.run(kwin_script)
+

--- a/lib/autokey/macro.py
+++ b/lib/autokey/macro.py
@@ -7,9 +7,6 @@ from autokey import common
 
 import autokey.scripting
 
-import gettext
-# Defines "_" function for localisation
-gettext.install("autokey")
 
 if common.USED_UI_TYPE == "QT":
     from PyQt5.QtWidgets import QAction

--- a/lib/autokey/model/phrase.py
+++ b/lib/autokey/model/phrase.py
@@ -49,7 +49,7 @@ class Phrase(AbstractAbbreviation, AbstractHotkey, AbstractWindowFilter):
         self.matchCase = False
         self.parent = None
         self.show_in_tray_menu = False
-        self.sendMode = SendMode.CB_CTRL_V
+        self.sendMode = SendMode.KEYBOARD
         self.path = path
 
     def build_path(self, base_name=None):

--- a/lib/autokey/monitor.py
+++ b/lib/autokey/monitor.py
@@ -77,7 +77,7 @@ class FileMonitor(threading.Thread):
         self.manager = WatchManager()
         self.notifier = Notifier(self.manager, self.__p)
         self.event = threading.Event()
-        self.daemon = True
+        self.setDaemon(True)
         self.watches = []
         self.__isSuspended = False
 
@@ -120,7 +120,7 @@ class FileMonitor(threading.Thread):
                 break
 
     def run(self):
-        while not self.event.is_set():
+        while not self.event.isSet():
             self.notifier.process_events()
             if self.notifier.check_events(1000):
                 self.notifier.read_events()

--- a/lib/autokey/qtapp.py
+++ b/lib/autokey/qtapp.py
@@ -96,7 +96,10 @@ class Application(AutokeyUIInterface, QApplication, AutokeyApplication, metaclas
         self.notifier.create_assign_context_menu()
 
     def path_created_or_modified(self, path):
-        UI_common.path_created_or_modified(self.configManager, self.configWindow, path)
+        try:
+            UI_common.path_created_or_modified(self.configManager, self.configWindow, path)
+        except AttributeError:
+            logger.exception('Unexpected exception.  If this is the first time AutoKey has been started on this system, then this exception can safely be ignored.')
 
     def path_removed(self, path):
         UI_common.path_removed(self.configManager, self.configWindow, path)

--- a/lib/autokey/scripting/__init__.py
+++ b/lib/autokey/scripting/__init__.py
@@ -34,17 +34,31 @@ from .system import System
 
 # Platform abstraction; Allows code like `import scripting.Dialog`
 if autokey.common.USED_UI_TYPE == "QT":
-    from .clipboard_qt import QtClipboard as Clipboard
+    if autokey.common.SESSION_TYPE == "wayland":
+        from .clipboard_wayland import WaylandClipboard as Clipboard
+    else:
+        from .clipboard_qt import QtClipboard as Clipboard
     from .dialog_qt import QtDialog as Dialog
 elif autokey.common.USED_UI_TYPE == "GTK":
-    from .clipboard_gtk import GtkClipboard as Clipboard
+    if autokey.common.SESSION_TYPE == "wayland":
+        from .clipboard_wayland import WaylandClipboard as Clipboard
+    else:
+        from .clipboard_gtk import GtkClipboard as Clipboard
     from .dialog_gtk import GtkDialog as Dialog
 elif autokey.common.USED_UI_TYPE == "headless":
-    from .clipboard_tkinter import TkClipboard as Clipboard
+    if autokey.common.SESSION_TYPE == "wayland":
+        from .clipboard_wayland import WaylandClipboard as Clipboard
+    else:
+        from .clipboard_tkinter import TkClipboard as Clipboard
     # Doesn't actually use anything gtk-specific.
     from .dialog_gtk import GtkDialog as Dialog
 
 if autokey.common.SESSION_TYPE == "wayland":
-    from .window_gnome import Window
-else:
-    from autokey.scripting.window import Window
+    if autokey.common.DESKTOP == 'KDE':
+        from .window_kde import Window
+    else:
+        from .window_gnome import Window
+    pass
+elif autokey.common.SESSION_TYPE == "x11":
+    from .window import Window
+    pass

--- a/lib/autokey/scripting/abstract_window.py
+++ b/lib/autokey/scripting/abstract_window.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 sebastiansam55
+# Copyright (C) 2024 Sam Sebastian
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/autokey/scripting/clipboard_gtk.py
+++ b/lib/autokey/scripting/clipboard_gtk.py
@@ -44,7 +44,7 @@ class GtkClipboard(AbstractClipboard):
         """
         self._selection = Gtk.Clipboard.get(Gdk.SELECTION_PRIMARY)
         """
-        Refers to the selection of the clipboard or the highlighted text
+        Refers to the "selection" of the clipboard or the highlighted text
         """
         self.app = app
         """
@@ -69,9 +69,9 @@ class GtkClipboard(AbstractClipboard):
 
     def get_selection(self):
         """
-        Read text from the selection
+        Read text from the X selection
 
-        Refers to the currently-highlighted text
+        The X selection refers to the currently highlighted text.
 
         Usage: C{clipboard.get_selection()}
 
@@ -109,7 +109,7 @@ class GtkClipboard(AbstractClipboard):
         Usage: C{clipboard.get_clipboard()}
 
         :return: text contents of the clipboard
-        :rtype: C{str}
+        :rtype: C{str}, or C{bytearray} on Python >= 3.13
         """
         Gdk.threads_enter()
         text = self._clipboard.wait_for_text()
@@ -127,8 +127,8 @@ class GtkClipboard(AbstractClipboard):
 
         Usage: C{clipboard.set_clipboard_image(path)}
 
-        :param path: path to image file
-        :raise OSError: if path does not exist
+        :param path: Path to image file
+        :raise OSError: If path does not exist
 
         """
         image_path = Path(path).expanduser()

--- a/lib/autokey/scripting/clipboard_qt.py
+++ b/lib/autokey/scripting/clipboard_qt.py
@@ -19,7 +19,7 @@ class QtClipboard(AbstractClipboard):
 
     def __init__(self, app=None):
         """
-        Initialize the Qt version of the clipboard
+        Initialize the Qt version of the Clipboard
 
         Usage: Called when QtClipboard is imported.
 
@@ -47,7 +47,7 @@ class QtClipboard(AbstractClipboard):
 
     def fill_selection(self, contents):
         """
-        Copy text into the selection
+        Copy text into the X selection
 
         Usage: C{clipboard.fill_selection(contents)}
 
@@ -69,7 +69,7 @@ class QtClipboard(AbstractClipboard):
 
     def get_selection(self):
         """
-        Read text from the selection
+        Read text from the X selection
 
         Usage: C{clipboard.get_selection()}
 
@@ -86,7 +86,7 @@ class QtClipboard(AbstractClipboard):
 
     def fill_clipboard(self, contents):
         """
-        Copy text onto the clipboard
+        Copy text into the clipboard
 
         Usage: C{clipboard.fill_clipboard(contents)}
 
@@ -126,7 +126,7 @@ class QtClipboard(AbstractClipboard):
         Usage: C{clipboard.get_clipboard()}
 
         :return: text contents of the clipboard
-        :rtype: C{str}
+        :rtype: C{str}, or C{bytearray} on Python >= 3.13
         """
         self.__execAsync(self.__getClipboard)
         return str(self.text)

--- a/lib/autokey/scripting/clipboard_wayland.py
+++ b/lib/autokey/scripting/clipboard_wayland.py
@@ -1,0 +1,179 @@
+#  Copyright (C) 2026 David King <dave@daveking.com>
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#####################################################################
+
+"""
+Implementation of the clipboard API functions on a Wayland system
+"""
+
+try:
+    from .abstract_clipboard import AbstractClipboard
+except:
+    #  For standalone testing
+    pass
+
+import subprocess
+import pathlib
+import re
+
+try:
+    logger = __import__("autokey.logger").logger.get_logger(__name__)
+except Exception:
+    #  For standalone testing
+    import logging
+    logging.basicConfig(format='%(asctime)s: %(levelname)s: %(message)s', datefmt='%d-%b-%y %H:%M:%S', level=logging.DEBUG)
+    logger = logging.getLogger(__name__)
+
+# Swap these lines for standalone testing:
+#class WaylandClipboard():
+class WaylandClipboard(AbstractClipboard):
+    """
+    Read write access to the Wayland desktop using the wl-clipboard utility
+    """
+    def __init__(self, app=None):
+        """
+        Initialize the Wayland version of the clipboard API
+
+        Usage: Called when WaylandClipboard is imported
+
+        :param app: refers to the application instance
+        """
+        self.app = app
+        
+    def fill_clipboard(self, contents: str):
+        """
+        Copy text into the clipboard
+
+        Usage: C{clipboard.fill_clipboard(contents)}
+
+        :param contents: string to be placed in the selection
+        """
+        try:
+            subprocess.run(['wl-copy', contents], check=True)
+        except subprocess.CalledProcessError:
+            logger.exception('Unexpected error running wl-copy program.  AutoKey continues.')
+        return
+        
+    def get_clipboard(self):
+        """
+        Read text from the clipboard
+
+        Usage: C{clipboard.get_clipboard()}
+
+        :return: text contents of the clipboard
+        :rtype: C{str}, or C{bytearray} on Python >= 3.13
+        """
+        try:
+            proc = subprocess.run(['wl-paste'], check=True, capture_output=True)
+            if proc.stdout is not None:
+                return re.sub(b'[\r\n]*$', b'', proc.stdout)
+            else: 
+                logger.warning("No content available from the clipboard")
+        except subprocess.CalledProcessError as e:
+            if e.returncode == 1:
+                logger.warning("No content available from the clipboard")
+                return ""
+            logger.exception('Unexpected error running wl-copy program.  AutoKey continues.')
+        return ""
+
+    def fill_selection(self, contents: str):
+        """
+        Copy text into the selection
+        
+        Usage: C{clipboard.fill_selection(contents)}
+
+        :param contents: string to be placed in the selection
+        """
+        try:
+            subprocess.run(['wl-copy', '--primary', contents], check=True)
+        except subprocess.CalledProcessError:
+            logger.exception('Unexpected error running wl-copy program.  AutoKey continues.')
+        return
+
+    def get_selection(self):
+        """
+        Read text from the X selection
+        The selection refers to the currently highlighted text.
+
+        **Notice:**  This is not possible under Wayland.
+
+        Usage: C{clipboard.get_selection()}
+
+        :return: text contents of the mouse selection
+        :rtype: C{str}
+        """
+        try:
+            proc = subprocess.run(['wl-paste', '--primary'], check=True, capture_output=True)
+            if proc.stdout is not None:
+                return re.sub(b'[\r\n]*$', b'', proc.stdout)
+            else: 
+                logger.warning("No content selected on desktop")
+        except subprocess.CalledProcessError as e:
+            if e.returncode == 1:
+                logger.warning("No content selected on desktop")
+                return ""
+            logger.exception('Unexpected error running wl-copy program.  AutoKey continues.')
+        return ""
+
+    def set_clipboard_image(self, path: str):
+        """
+        Set clipboard to image
+
+        Usage: C{clipboard.set_clipboard_image(path)}
+
+        :param path: Path to image file
+        :raise OSError: If path does not exist
+        """
+        try:
+            image_file = pathlib.Path(path).expanduser()
+            if image_file.exists():
+                subprocess.run(f'wl-copy <{image_file}', shell=True, check=True)
+        except subprocess.CalledProcessError:
+            logger.exception('Unexpected error running wl-copy program.  AutoKey continues.')
+        return
+
+#  For standalone testing
+if __name__ == '__main__':
+    import datetime
+    
+    logger.debug('Instantiating clipboard')
+    clipboard = WaylandClipboard()
+
+    logger.debug('Testing the regular clipboard')
+    logger.debug(f'\tThe clipboard\'s current content = "{clipboard.get_clipboard()}"')   
+    test_content = f'The current date and time are {datetime.datetime.now()}'
+    logger.debug('\tPushing test string onto clipboard')
+    clipboard.fill_clipboard(test_content)
+    logger.debug('\tPulling text from clipboard')
+    result = clipboard.get_clipboard()
+    if result == test_content:
+        logger.debug('\tThe text pulled matches the text pushed')
+    else:
+        logger.error(f'\tThe text pushed, "{test_content}", does not match the text pulled, "{result}"')
+    logger.debug('\tPushing image file to clipboard, try creating a new image from the cliboard with a tool like GIMP')
+    clipboard.set_clipboard_image('~/src/autokey-wayland/readthedocs/editconfig.jpg')
+
+    logger.debug('Testing the primary (selection) clipboard')
+    logger.debug(f'\tThe primary clipboard\'s current content = "{clipboard.get_selection()}"')   
+    test_content = f'The current date and time are {datetime.datetime.now()}'
+    logger.debug('\tPushing test string onto primary clipboard')
+    clipboard.fill_selection(test_content)
+    logger.debug('\tPulling text from primary clipboard')
+    result = clipboard.get_selection()
+    if result == test_content:
+        logger.debug('\tThe text pulled matches the text pushed')
+    else:
+        logger.error(f'\tThe text pushed, "{test_content}", does not match the text pulled, "{result}"')

--- a/lib/autokey/scripting/engine.py
+++ b/lib/autokey/scripting/engine.py
@@ -77,7 +77,7 @@ class Engine:
 
         Descriptions for the optional arguments:
 
-        :param parentFolder: Folder to make this folder a subfolder of. If
+        :param parent_folder: Folder to make this folder a subfolder of. If
             passed as a folder, it will be that folder within AutoKey.
             If passed as pathlib.Path, it will be created or added at that path.
             Paths expand ~ to $HOME.
@@ -350,7 +350,7 @@ Folders created within temporary folders must themselves be set temporary")
         """
         Run an existing script using its description or path to look it up
 
-        Usage: C{engine.run_script(description, 'foo', 'bar', foobar='foobar')}
+        Usage: C{engine.run_script(description, 'foo', 'bar', foobar='foobar'})}
 
         :param description: description of the script to run. If parsable as
             an absolute path to an existing file, that will be run instead.

--- a/lib/autokey/scripting/highlevel.py
+++ b/lib/autokey/scripting/highlevel.py
@@ -132,7 +132,7 @@ def click_on_pat(pat: str, mousebutton: int=1, offset: (float, float)=None, tole
     :param offset: offset from the top left point of the match. (float,float)
     :param tolerance: An integer ≥ 0 to specify the level of tolerance for 'fuzzy' matches. If negative or not convertible to int, raises ValueError.
     :param restore_pos: return to the initial mouse position after the click.
-    :raises: L{PatternNotFound}: Raised when the pattern is not found on the screen
+    :raise PatternNotFound: Raised when the pattern is not found on the screen
     """
     x0, y0 = mouse_pos()
     move_to_pat(pat, offset, tolerance)

--- a/lib/autokey/scripting/keyboard.py
+++ b/lib/autokey/scripting/keyboard.py
@@ -15,11 +15,15 @@
 """Keyboard Functions"""
 
 import typing
+import time
 
 import autokey.model.phrase
 import autokey.iomediator.waiter as waiter
 from autokey import iomediator, model
 from typing import Callable
+
+import autokey.configmanager.configmanager as cm
+import autokey.configmanager.configmanager_constants as cm_constants
 
 class Keyboard:
     """
@@ -32,7 +36,7 @@ class Keyboard:
         self.mediator = mediator  # type: iomediator.IoMediator
         """See C{IoMediator} documentation"""
 
-    def send_keys(self, key_string, send_mode: typing.Union[
+    def send_keys(self, key_string, delay = 0, send_mode: typing.Union[
         autokey.model.phrase.SendMode, int] = autokey.model.phrase.SendMode.KEYBOARD):
         """
         Send a sequence of keys via keyboard events as the default or via clipboard pasting.
@@ -42,16 +46,22 @@ class Keyboard:
         Trying to send special keys using a clipboard pasting method will paste the literal representation
         (e.g. "<ctrl>+<f11>") instead of the actual special key or key combination.
 
-
         Usage: C{keyboard.send_keys(keyString)}
 
         :param key_string: string of keys to send. Special keys are only possible in keyboard mode.
+        :param delay: delay, in milliseconds, between sending each keystroke.  Only effective under Wayland, has no effect on X11 systems.
         :param send_mode: Determines how the string is sent.
         """
 
         if not isinstance(key_string, str):
             raise TypeError("Only strings can be sent using this function")
         send_mode = _validate_send_mode(send_mode)
+
+        #  @dlk3 Fix for #19 - Temporarily change the setting for the uinput keystoke delay
+        if delay > 0:
+            saved_delay = cm.ConfigManager.SETTINGS[cm_constants.DELAY] 
+            cm.ConfigManager.SETTINGS[cm_constants.DELAY] = saved_delay + delay
+
         self.mediator.begin_send()
         try:
             if send_mode is autokey.model.phrase.SendMode.KEYBOARD:
@@ -60,6 +70,11 @@ class Keyboard:
                 self.mediator.paste_string(key_string, send_mode)
         finally:
             self.mediator.finish_send()
+        
+        #  @dlk3 Fix for #19 - Temporarily change the setting for the uinput keystoke delay
+        if delay > 0:
+            time.sleep(len(key_string) * delay / 1000)    # Give the thread that does the typing time to complete
+            cm.ConfigManager.SETTINGS[cm_constants.DELAY] = saved_delay
 
     def send_key(self, key, repeat=1):
         """
@@ -119,6 +134,7 @@ class Keyboard:
         Usage: C{keyboard.wait_for_keypress(self, key, modifiers=[], timeOut=10.0)}
 
         Note: this function cannot be used to wait for modifier keys on their own
+
 
         :param key: the key to wait for
         :param modifiers: list of modifiers that should be pressed with the key

--- a/lib/autokey/scripting/mouse.py
+++ b/lib/autokey/scripting/mouse.py
@@ -67,8 +67,8 @@ class Mouse:
 
         Usage: C{mouse.click_absolute(x, y, button)}
 
-        :param x: x-coordinate in pixels, relative to upper left corner of screen
-        :param y: y-coordinate in pixels, relative to upper left corner of screen
+        :param x: x-coordinate in pixels, relative to upper left corner of window
+        :param y: y-coordinate in pixels, relative to upper left corner of window
         :param button: mouse button to simulate (left=1, middle=2, right=3)
         """
         self.interface.send_mouse_click(x, y, button, False)

--- a/lib/autokey/scripting/system.py
+++ b/lib/autokey/scripting/system.py
@@ -60,7 +60,7 @@ class System:
 
         Usage: C{system.create_file(fileName, contents="")}
 
-        :param fileName: full path to the file to be created
+        :param file_name: full path to the file to be created
         :param contents: contents to insert into the file
         """
         with open(file_name, "w") as written_file:

--- a/lib/autokey/scripting/window.py
+++ b/lib/autokey/scripting/window.py
@@ -31,14 +31,12 @@ XRANDR_MONITOR_REGEX = r" (\d{3,4}).*?x(\d{3,4})\/.*?\+(\d{1,4})\+(\d{1,4})"
 # this translates to monitor x and y size, and x and y offset for each monitor
 
 class Window:
-    r"""
+    """
     Basic window management using wmctrl
 
     Note: in all cases where a window title is required (with the exception of wait_for_focus()),
     two special values of window title are permitted:
 
-    - :\:ACTIVE: - select the currently active window
-    - :\:SELECT: - select the desired window by clicking on it
     """
 
     def __init__(self, mediator):

--- a/lib/autokey/scripting/window_gnome.py
+++ b/lib/autokey/scripting/window_gnome.py
@@ -1,30 +1,38 @@
-# Copyright (C) 2011 Chris Dekter
+#  Copyright (C) 2023 Sam Sebastian
+#  Copyright (C) 2026 David King
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
 #
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
 #
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#####################################################################
 
-"""Extremely basic window management. Requires autokey gnome extension"""
+"""
+Desktop window management based on the AutoKey GNOME Shell extension
+"""
 
 import re
 import subprocess
 import time
 from .abstract_window import AbstractWindow
+import socket
+import os
+import json
 
-#TODO review how desktop/workspace switching works with gnome extension. I think this may be in "workspace"
+logger = __import__("autokey.logger").logger.get_logger(__name__)
 
 class Window(AbstractWindow):
     """
-    Extremely basic Window management with gnome autokey extension
+    Window management with AutoKey GNOME Shell extension
     """
 
     def __init__(self, mediator):
@@ -32,13 +40,45 @@ class Window(AbstractWindow):
 
     def wait_for_focus(self, title, timeOut=5):
         """
+        Wait for window with the given title to have focus
+
+        Usage: C{window.wait_for_focus(title, timeOut=5)}
+
+        If the window becomes active, returns True. Otherwise, returns False if
+        the window has not become active by the time the timeout has elapsed.
+
+        :param title: title to match against (as a regular expression)
+        :param timeOut: period (seconds) to wait before giving up
+        :rtype: boolean
         """
-        raise NotImplementedError
+        start = time.time()
+        while time.time() - start <= timeOut:
+            for item in self.mediator.windowInterface.get_window_list():
+                if item['focus'] and re.search(rf'{title}', item['wm_title'], re.IGNORECASE):
+                    return True
+            time.sleep(0.3)
+        return False
 
     def wait_for_exist(self, title, timeOut=5, by_hex=False):
         """
+        Wait for window with the given title to be created
+
+        Usage: C{window.wait_for_exist(title, timeOut=5)}
+
+        If the window is in existence, returns True. Otherwise, returns False if the window has not been created by the time the timeout has elapsed.
+
+        :param title: title to match against (as a regular expression)
+        :param timeOut: period (seconds) to wait before giving up
+        :param by_hex: If true, will interpret the C{title} as a hexid
+        :rtype: boolean
         """
-        raise NotImplementedError
+        start = time.time()
+        while time.time() - start <= timeOut:
+            for item in self.mediator.windowInterface.get_window_list():
+                if (by_hex and by_hex == item['id']) or re.search(rf'{title}', item['wm_title'], re.IGNORECASE):
+                    return True
+            time.sleep(0.3)
+        return False
 
     def activate(self, title, switchDesktop=False, matchClass=False, by_hex=False):
         """
@@ -49,65 +89,198 @@ class Window(AbstractWindow):
         If switchDesktop is False (default), the window will be moved to the current desktop and activated. Otherwise, switch to the window's current desktop and activate it there.
 
         :param title: window title to match against (as case-insensitive substring match)
-        :param switchDesktop: not supported for gnome extension
+        :param switchDesktop: If True, switch to desktop where window resides and activate
         :param matchClass: if True, match on the window class instead of the title
-        :param by_hex: not supported for gnome extension
+        :param by_hex: If true, interpret the C{title} as a hexid
         """
-        if switchDesktop or by_hex:
-            raise NotImplementedError
-
-        windows = self.get_window_list()
-        for window in windows:
-            if not matchClass and title in window.get('wm_title'):
-                self.mediator.windowInterface.activate_window(window.get('id'))
-            elif matchClass and title in window.get('wm_class'):
-                self.mediator.windowInterface.activate_window(window.get('id'))
+        target_window = self.__get_target_window(title, matchClass, by_hex)
+        if target_window:
+            #logger.debug(f'window API: target window details:\n{json.dumps(target_window, indent=4)}')
+            if switchDesktop:
+                self.mediator.windowInterface.switch_workspace(target_window['workspace'])
+            else:
+                wksid = self.mediator.windowInterface.get_active_desktop_index()
+                self.mediator.windowInterface.move_to_workspace(target_window['id'], wksid)
+            self.mediator.windowInterface.activate_window(target_window['id'])
         return
 
     def close(self, title, matchClass=False, by_hex=False):
         """
         Close the specified window gracefully
 
-        Usage: C{window.close(title, matchClass=False)}
+        Usage: C{window.close(title, matchClass=False), by_hex=False}
 
         :param title: window title to match against (as case-insensitive substring match)
         :param matchClass: if True, match on the window class instead of the title
-        :param by_hex: not supported for gnome extension
+        :param by_hex: If true, interpret the C{title} as a hexid
         """
-
-        windows = self.get_window_list()
-        for window in windows:
-            #TODO regex support
-            if not matchClass and title in window.get('wm_title'):
-                self.mediator.windowInterface.close_window(window.get('id'))
-            elif matchClass and title in window.get('wm_class'):
-                self.mediator.windowInterface.close_window(window.get('id'))
-        return
+        target_window = self.__get_target_window(title, matchClass, by_hex)
+        if target_window:
+            #logger.debug(f'window API: target window details:\n{json.dumps(target_window, indent=4)}')
+            self.mediator.windowInterface.close_window(target_window['id'])
 
     def resize_move(self, title, xOrigin=-1, yOrigin=-1, width=-1, height=-1, matchClass=False, by_hex=False):
         """
+        Resize and/or move the specified window
+
+        Usage: C{window.resize_move(title, xOrigin=-1, yOrigin=-1, width=-1, height=-1, matchClass=False)}
+
+        Leaving any of the position/dimension values as the default (-1) will cause that
+        value to be left unmodified.
+
+        :param title: window title to match against (as case-insensitive substring match)
+        :param xOrigin: new x origin of the window (upper left corner)
+        :param yOrigin: new y origin of the window (upper left corner)
+        :param width: new width of the window
+        :param height: new height of the window
+        :param matchClass: if C{True}, match on the window class instead of the title
+        :param by_hex: If true, interpret the C{title} as a hexid
         """
-        raise NotImplementedError
+        target_window = self.__get_target_window(title, matchClass, by_hex)
+        if target_window:
+            #logger.debug(f'window API: target window details:\n{json.dumps(target_window, indent=4)}')
+            hexid = target_window['id']
+            if xOrigin == -1:
+                xOrigin = target_window['x']
+            if yOrigin == -1:
+                yOrigin = target_window['y']
+            if width == -1:
+                width = target_window['width']
+            if height == -1:
+                height = target_window['height']
+            self.mediator.windowInterface.move_resize_window(hexid, xOrigin, yOrigin, width, height)
+        return
 
     def move_to_desktop(self, title, deskNum, matchClass=False, by_hex=False):
         """
+        Move window to specified desktop (GNOME workspace)
+
+        Usage: C{window.move_to_desktop(title, desknum, matchClass=False, by_hex=False)}
+
+        :param title: window title to match against (as case-insensitive substring match)
+        :param desknum: the number of the desktop (workspace) to which to move this window (note: zero based)
+        :param matchClass: if C{True}, match on the window class instead of the title
+        :param by_hex: If true, interpret the C{title} as a hexid
         """
-        raise NotImplementedError
+        target_window = self.__get_target_window(title, matchClass, by_hex)
+        if target_window:
+            #logger.debug(f'window API: target window details:\n{json.dumps(target_window, indent=4)}')
+            hexid = target_window['id']
+            self.mediator.windowInterface.move_to_workspace(hexid, deskNum)
 
     def switch_desktop(self, deskNum):
         """
+        Switch to the specified desktop (GNOME workspace)
+
+        Usage: C{window.switch_desktop(deskNum)}
+
+        :param deskNum: desktop to switch to (note: zero based)
         """
-        raise NotImplementedError
+        self.mediator.windowInterface.switch_workspace(deskNum)
 
     def set_property(self, title, action, prop, matchClass=False, by_hex=False):
         """
+        Set a property on the given window using the specified action
+
+        Usage: C{window.set_property(title, action, prop, matchClass=False, by_hex=False)}
+
+        Allowable actions:
+
+        - add
+        - remove
+        - toggle
+
+        Properties available in the GNOME environment:
+
+        - sticky  ("add" or "remove" only, no "toggle")
+        - maximized_vert
+        - maximized_horz
+        - fullscreen
+        - above
+
+        :param title: window title to match against (as case-insensitive substring match)
+        :param action: one of the actions listed above
+        :param prop: one of the properties listed above
+        :param matchClass: if True, match on the window class instead of the title
+        :param by_hex: If true, will interpret the C{title} as a hexid
         """
-        raise NotImplementedError
+        target_window = self.__get_target_window(title, matchClass, by_hex)
+        if target_window:
+            #logger.debug(f'window API: target window details:\n{json.dumps(target_window, indent=4)}')
+            properties = self.mediator.windowInterface.get_properties(target_window['id'])
+            if prop == 'sticky':
+                if action == 'toggle':
+                    logger.error('Current sticky state unknown, "toggle" action is not supported in window.set_property()')
+                elif action == 'add':
+                    self.mediator.windowInterface.stick_window(target_window['id'])
+                elif action == 'remove':
+                    self.mediator.windowInterface.unstick_window(target_window['id'])
+                else:
+                    logger.error(f'Unknown action "{action}" in window.set_property()')
+            if prop == 'maximized_vert':
+                if action == 'toggle':
+                    if properties['is_maximized_vert']:
+                        self.mediator.windowInterface.unmaximize_window(target_window['id'], 2)
+                    else:
+                        self.mediator.windowInterface.maximize_window(target_window['id'], 2)
+                elif action == 'add':
+                    self.mediator.windowInterface.maximize_window(target_window['id'], 2)
+                elif action == 'remove':
+                    self.mediator.windowInterface.unmaximize_window(target_window['id'], 2)
+                else:
+                    logger.error(f'Unknown action "{action}" in window.set_property()')
+            elif prop == 'maximized_horz':
+                if action == 'toggle':
+                    if properties['is_maximized_vert']:
+                        self.mediator.windowInterface.unmaximize_window(target_window['id'], 1)
+                    else:
+                        self.mediator.windowInterface.maximize_window(target_window['id'], 1)
+                elif action == 'add':
+                    self.mediator.windowInterface.maximize_window(target_window['id'], 1)
+                elif action == 'remove':
+                    self.mediator.windowInterface.unmaximize_window(target_window['id'], 1)
+                else:
+                    logger.error(f'Unknown action "{action}" in window.set_property()')
+            elif prop == 'fullscreen':
+                if action == 'toggle':
+                    if properties['is_fullscreen']:
+                        self.mediator.windowInterface.unmake_fullscreen_window(target_window['id'])
+                    else:
+                        self.mediator.windowInterface.make_fullscreen_window(target_window['id'])
+                elif action == 'add':
+                    self.mediator.windowInterface.make_fullscreen_window(target_window['id'])
+                elif action == 'remove':
+                    self.mediator.windowInterface.unmake_fullscreen_window(target_window['id'])
+                else:
+                    logger.error(f'Unknown action "{action}" in window.set_property()')
+            elif prop == 'above':
+                if action == 'toggle':
+                    if properties['is_above']:
+                        self.mediator.windowInterface.unmake_above_window(target_window['id'])
+                    else:
+                        self.mediator.windowInterface.make_above_window(target_window['id'])
+                elif action == 'add':
+                    self.mediator.windowInterface.make_above_window(target_window['id'])
+                elif action == 'remove':
+                    self.mediator.windowInterface.unmake_above_window(target_window['id'])
+                else:
+                    logger.error(f'Unknown action "{action}" in window.set_property()')
+            else:
+                logger.error(f'Unknown or unimplemented property "{prop}" in window.set_property()')
+        return
 
     def get_active_geometry(self):
         """
+        Get the geometry of the currently active window.
+
+        Usage: C{window.get_active_geometry()}
+
+        :return: a 4-tuple containing the x-origin, y-origin, width and height of the window (in pixels)
+        :rtype: C{tuple(int, int, int, int)}
         """
-        raise NotImplementedError
+        #wrapper for get_window_geometry()
+        return self.get_window_geometry(":ACTIVE:")
+
 
     def get_active_title(self):
         """
@@ -131,14 +304,39 @@ class Window(AbstractWindow):
         """
         return self.mediator.windowInterface.get_window_class()
 
-    def center_window(self, title=":ACTIVE:", win_width=None, win_height=None, monitor=0, matchClass=False, by_hex=False):
+    def center_window(self, title=":ACTIVE:", win_width=None, win_height=None, matchClass=False, by_hex=False):
         """
+        Centers the active (or window selected by title) window.
+
+        :param title: Title of the window to center (defaults to using the active window)
+        :param win_width: Width of the centered window, defaults to screenx/3. Use -1 to center without size change.
+        :param win_height: Height of the centered window, defaults to screeny/3. Use -1 to center without size change.
+        :param matchClass: if True, match on the window class instead of the title
+        :param by_hex: If true, interpret the C{title} as a hexid
         """
-        raise NotImplementedError
+        (screen_width, screen_height) = self.mediator.windowInterface.get_screen_size()
+        try:
+            target_window = self.__get_target_window(title, matchClass, by_hex)
+            if target_window:
+                #logger.debug(f'window API: target window details:\n{json.dumps(target_window, indent=4)}')
+                if win_width == -1:
+                    win_width = target_window['width']
+                elif not win_width:
+                    win_width = screen_width // 3
+                if win_height == -1:
+                    win_height = target_window['height']
+                elif not win_height:
+                    win_height = screen_height // 3
+                x = (screen_width - win_width) // 2
+                y = (screen_height - win_height) // 2
+                self.resize_move(title, x, y, win_width, win_height, matchClass=matchClass, by_hex=by_hex)
+        except Exception as e:
+            logger.error('window.center_window() script API unable to get a valid numeric screen resolution')
+        return
 
     def get_window_list(self, filter_desktop=-1):
         """
-        Returns a list of windows matching an optional desktop filter, requires C{wmctrl}!
+        Returns a list of windows matching an optional desktop filter, requires AutoKey GNOME Shell extension!
 
         Each list item consists of: C{[hexid, desktop, hostname, title]}
 
@@ -150,23 +348,84 @@ class Window(AbstractWindow):
 
         C{title} is the title that you would usually see in your window manager of choice.
 
-        :param filter_desktop: Not currently supported
+        :param filter_desktop (note: zero based)
         :return: C{[[hexid1, desktop1, hostname1, title1], [hexid2,desktop2,hostname2,title2], ...etc]} Returns C{[]} if no windows are found.
         """
-        if filter_desktop!=-1:
-            raise NotImplementedError
-        return self.mediator.windowInterface.get_window_list()
+        output_list = []
+        for item in self.mediator.windowInterface.get_window_list():
+            window = (
+                item['id'],
+                item['workspace'],
+                socket.gethostname(),
+                item['wm_title']
+            )
+            if filter_desktop != -1:
+                if item['workspace'] == filter_desktop:
+                    output_list.append(window)
+            else:
+                output_list.append(window)
+        return output_list
 
     def get_window_hex(self, title):
         """
+        Returns the hexid of the first window to match title.
+
+        :param title: Window title to match for returning hexid.  Use ":ACTIVE:" to specify the window that currently has focus on the desktop.
+        :return: Returns hexid of the window to be used for other functions See L{get_window_geom}, L{visgrep_by_window_id}
+
+        Returns C{None} if no matches are found
         """
-        raise NotImplementedError
+        target_window = self.__get_target_window(title, False, False)
+        if target_window:
+            #logger.debug(f'window API: target window details:\n{json.dumps(target_window, indent=4)}')
+            return target_window['id']
+        return None
 
-
-
-
-    def get_window_geometry(self, title, by_hex=False):
+    def get_window_geometry(self, title, matchClass=False, by_hex=False):
         """
-        """
+        Returns the window geometry of the given window title. Returns where the location of the
+        top left hand corner of the window is and the width/height of the window.
 
-        raise NotImplementedError
+        :param title: Window title to match for returning geometry.  Use ":ACTIVE:" to specify the window that currently has focus on the desktop.
+        :param matchClass: if True, match on the window class instead of the title
+        :param by_hex: If true, interpret the C{title} as a hexid
+        :return: C{[offsetx, offsety, sizex, sizey]} Returns none if no matches are found
+
+        Returns C{None} if no matching window was found
+        """
+        target_window = self.__get_target_window(title, matchClass, by_hex)
+        if target_window:
+            #logger.debug(f'window API: target window details:\n{json.dumps(target_window, indent=4)}')
+            return (target_window['x'], target_window['y'], target_window['width'], target_window['height'])
+        return None
+
+    def __get_target_window(self, title, matchClass, by_hex):
+        """
+        A utility function that searches for a window on the desktop that matches
+        s specific set of criteria.  This function is used by several of the
+        functions in this class.
+
+        :param title: window title to match against (as case-insensitive substring match)
+        :param matchClass: if C{True}, match on the window class instead of the title
+        :param by_hex: If true, interpret the C{title} as a hexid
+        :return: A dictionary containing the data the AutoKey GNOME Shell extension found for the matching window
+
+        Returns C{None} if no matching window was found
+        """
+        if by_hex and matchClass:
+            logger.warning('window API: both by_hex and matchClass are set True, ignoring matchClass and continuing')
+
+        for win in self.mediator.windowInterface.get_window_list():
+            if by_hex:
+                if win['id'] == title:
+                    return win
+            else:
+                if matchClass:
+                     if re.search(rf'{title}', win['wm_class'], re.IGNORECASE):
+                        return win
+                else:
+                    if title == ':ACTIVE:' and win['focus']:
+                        return win
+                    elif re.search(rf'{title}', win['wm_title'], re.IGNORECASE):
+                        return win
+        return None

--- a/lib/autokey/scripting/window_kde.py
+++ b/lib/autokey/scripting/window_kde.py
@@ -1,0 +1,451 @@
+#  Copyright (C) 2023 Sam Sebastian
+#  Copyright (C) 2026 David King
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#####################################################################
+
+"""
+Desktop window management based on KDE KWin scripts
+"""
+
+import re
+import subprocess
+import time
+from .abstract_window import AbstractWindow
+import socket
+import os
+import json
+
+logger = __import__("autokey.logger").logger.get_logger(__name__)
+
+class Window(AbstractWindow):
+    """
+    Window management with AutoKey KDE KWin window interface
+    """
+
+    def __init__(self, mediator):
+        self.mediator = mediator
+
+    def wait_for_focus(self, title, timeOut=5):
+        """
+        Wait for window with the given title to have focus
+
+        Usage: C{window.wait_for_focus(title, timeOut=5)}
+
+        If the window becomes active, returns True. Otherwise, returns False if
+        the window has not become active by the time the timeout has elapsed.
+
+        :param title: title to match against (as a regular expression)
+        :param timeOut: period (seconds) to wait before giving up
+        :rtype: boolean
+        """
+        start = time.time()
+        while time.time() - start <= timeOut:
+            for item in self.mediator.windowInterface.get_window_list():
+                if item['focus'] and re.search(rf'{title}', item['wm_title'], re.IGNORECASE):
+                    return True
+            time.sleep(0.3)
+        return False
+
+    def wait_for_exist(self, title, timeOut=5, by_hex=False):
+        """
+        Wait for window with the given title to be created
+
+        Usage: C{window.wait_for_exist(title, timeOut=5)}
+
+        If the window is in existence, returns True. Otherwise, returns False if the window has not been created by the time the timeout has elapsed.
+
+        :param title: title to match against (as a regular expression)
+        :param timeOut: period (seconds) to wait before giving up
+        :param by_hex: If true, will interpret the C{title} as a hexid
+        :rtype: boolean
+        """
+        start = time.time()
+        while time.time() - start <= timeOut:
+            for item in self.mediator.windowInterface.get_window_list():
+                if (by_hex and by_hex == item['id']) or re.search(rf'{title}', item['wm_title'], re.IGNORECASE):
+                    return True
+            time.sleep(0.3)
+        return False
+
+    def activate(self, title, switchDesktop=False, matchClass=False, by_hex=False):
+        """
+        Activate the specified window, giving it input focus
+
+        Usage: C{window.activate(title, switchDesktop=False, matchClass=False)}
+
+        If switchDesktop is False (default), the window will be moved to the current desktop and activated. Otherwise, switch to the window's current desktop and activate it there.
+
+        :param title: window title to match against (as case-insensitive substring match)
+        :param switchDesktop: If True, switch to desktop where window resides and activate
+        :param matchClass: if True, match on the window class instead of the title
+        :param by_hex: If true, interpret the C{title} as a hexid
+        """
+        target_window = self.__get_target_window(title, matchClass, by_hex)
+        if target_window:
+            #logger.debug(f'window API: target window details:\n{json.dumps(target_window, indent=4)}')
+            if switchDesktop:
+                self.mediator.windowInterface.switch_workspace(target_window['workspace'])
+            else:
+                wksid = self.mediator.windowInterface.get_active_desktop_index()
+                self.mediator.windowInterface.move_to_workspace(target_window['id'], wksid)
+            self.mediator.windowInterface.activate_window(target_window['id'])
+        return
+
+    def close(self, title, matchClass=False, by_hex=False):
+        """
+        Close the specified window gracefully
+
+        Usage: C{window.close(title, matchClass=False), by_hex=False}
+
+        :param title: window title to match against (as case-insensitive substring match)
+        :param matchClass: if True, match on the window class instead of the title
+        :param by_hex: If true, interpret the C{title} as a hexid
+        """
+        target_window = self.__get_target_window(title, matchClass, by_hex)
+        if target_window:
+            #logger.debug(f'window API: target window details:\n{json.dumps(target_window, indent=4)}')
+            self.mediator.windowInterface.close_window(target_window['id'])
+
+    def resize_move(self, title, xOrigin=-1, yOrigin=-1, width=-1, height=-1, matchClass=False, by_hex=False):
+        """
+        Resize and/or move the specified window
+
+        Usage: C{window.resize_move(title, xOrigin=-1, yOrigin=-1, width=-1, height=-1, matchClass=False)}
+
+        Leaving any of the position/dimension values as the default (-1) will cause that
+        value to be left unmodified.
+
+        :param title: window title to match against (as case-insensitive substring match)
+        :param xOrigin: new x origin of the window (upper left corner)
+        :param yOrigin: new y origin of the window (upper left corner)
+        :param width: new width of the window
+        :param height: new height of the window
+        :param matchClass: if C{True}, match on the window class instead of the title
+        :param by_hex: If true, interpret the C{title} as a hexid
+        """
+        target_window = self.__get_target_window(title, matchClass, by_hex)
+        if target_window:
+            #logger.debug(f'window API: target window details:\n{json.dumps(target_window, indent=4)}')
+            hexid = target_window['id']
+            if xOrigin == -1:
+                xOrigin = target_window['x']
+            if yOrigin == -1:
+                yOrigin = target_window['y']
+            if width == -1:
+                width = target_window['width']
+            if height == -1:
+                height = target_window['height']
+            self.mediator.windowInterface.move_resize_window(hexid, xOrigin, yOrigin, width, height)
+        return
+
+    def move_to_desktop(self, title, deskNum, matchClass=False, by_hex=False):
+        """
+        Move window to specified desktop (GNOME workspace)
+
+        Usage: C{window.move_to_desktop(title, desknum, matchClass=False, by_hex=False)}
+
+        :param title: window title to match against (as case-insensitive substring match)
+        :param desknum: the number of the desktop (workspace) to which to move this window (note: zero based)
+        :param matchClass: if C{True}, match on the window class instead of the title
+        :param by_hex: If true, interpret the C{title} as a hexid
+        """
+        target_window = self.__get_target_window(title, matchClass, by_hex)
+        if target_window:
+            #logger.debug(f'window API: target window details:\n{json.dumps(target_window, indent=4)}')
+            self.mediator.windowInterface.move_to_workspace(target_window['id'], deskNum)
+
+    def switch_desktop(self, deskNum):
+        """
+        Switch to the specified desktop (GNOME workspace)
+
+        Usage: C{window.switch_desktop(deskNum)}
+
+        :param deskNum: desktop to switch to (note: zero based)
+        """
+        self.mediator.windowInterface.switch_workspace(deskNum)
+
+    def set_property(self, title, action, prop, matchClass=False, by_hex=False):
+        """
+        Set a property on the given window using the specified action
+
+        Usage: C{window.set_property(title, action, prop, matchClass=False, by_hex=False)}
+
+        Allowable actions:
+
+        - add
+        - remove
+        - toggle
+
+        Properties available in KDE environment:
+
+        - above
+        - fullscreen
+        - maximized_vert
+        - maximized_horz
+        - shaded
+        - skip_pager
+        - skip_taskbar
+
+        :param title: window title to match against (as case-insensitive substring match)
+        :param action: one of the actions listed above
+        :param prop: one of the properties listed above
+        :param matchClass: if True, match on the window class instead of the title
+        :param by_hex: If true, will interpret the C{title} as a hexid
+        """
+        target_window = self.__get_target_window(title, matchClass, by_hex)
+        if target_window:
+            #logger.debug(f'window API: target window details:\n{json.dumps(target_window, indent=4)}')
+            properties = self.mediator.windowInterface.get_properties(target_window['id'])
+            if prop == 'above':
+                if action == 'toggle':
+                    if properties['is_above']:
+                        self.mediator.windowInterface.unmake_above_window(target_window['id'])
+                    else:
+                        self.mediator.windowInterface.make_above_window(target_window['id'])
+                elif action == 'add':
+                    self.mediator.windowInterface.make_above_window(target_window['id'])
+                elif action == 'remove':
+                    self.mediator.windowInterface.unmake_above_window(target_window['id'])
+                else:
+                    logger.error(f'Unknown action "{action}" in window.set_property()')
+            elif prop == 'fullscreen':
+                if action == 'toggle':
+                    if properties['is_fullscreen']:
+                        self.mediator.windowInterface.unmake_fullscreen_window(target_window['id'])
+                    else:
+                        self.mediator.windowInterface.make_fullscreen_window(target_window['id'])
+                elif action == 'add':
+                    self.mediator.windowInterface.make_fullscreen_window(target_window['id'])
+                elif action == 'remove':
+                    self.mediator.windowInterface.unmake_fullscreen_window(target_window['id'])
+                else:
+                    logger.error(f'Unknown action "{action}" in window.set_property()')
+            elif prop == 'maximized_vert':
+                if action == 'toggle':
+                    if properties['is_maximized_vert']:
+                        self.mediator.windowInterface.unmaximize_window(target_window['id'], 2)
+                    else:
+                        self.mediator.windowInterface.maximize_window(target_window['id'], 2)
+                elif action == 'add':
+                    self.mediator.windowInterface.maximize_window(target_window['id'], 2)
+                elif action == 'remove':
+                    self.mediator.windowInterface.unmaximize_window(target_window['id'], 2)
+                else:
+                    logger.error(f'Unknown action "{action}" in window.set_property()')
+            elif prop == 'maximized_horz':
+                if action == 'toggle':
+                    if properties['is_maximized_vert']:
+                        self.mediator.windowInterface.unmaximize_window(target_window['id'], 1)
+                    else:
+                        self.mediator.windowInterface.maximize_window(target_window['id'], 1)
+                elif action == 'add':
+                    self.mediator.windowInterface.maximize_window(target_window['id'], 1)
+                elif action == 'remove':
+                    self.mediator.windowInterface.unmaximize_window(target_window['id'], 1)
+                else:
+                    logger.error(f'Unknown action "{action}" in window.set_property()')
+            elif prop == 'shaded':
+                if action == 'toggle':
+                    self.mediator.windowInterface.set_property(target_window['id'], 'shade', not properties['is_shaded'])
+                elif action == 'add':
+                    self.mediator.windowInterface.set_property(target_window['id'], 'shade', True)
+                elif action == 'remove':
+                    self.mediator.windowInterface.set_property(target_window['id'], 'shade', False)
+                else:
+                    logger.error(f'Unknown action "{action}" in window.set_property()')
+            elif prop == 'skip_pager':
+                if action == 'toggle':
+                    self.mediator.windowInterface.set_property(target_window['id'], 'skipPager', not properties['is_skip_pager'])
+                elif action == 'add':
+                    self.mediator.windowInterface.set_property(target_window['id'], 'skipPager', True)
+                elif action == 'remove':
+                    self.mediator.windowInterface.set_property(target_window['id'], 'skipPager', False)
+                else:
+                    logger.error(f'Unknown action "{action}" in window.set_property()')
+            elif prop == 'skip_taskbar':
+                if action == 'toggle':
+                    self.mediator.windowInterface.set_property(target_window['id'], 'skipTaskbar', not properties['is_skip_taskbar'])
+                elif action == 'add':
+                    self.mediator.windowInterface.set_property(target_window['id'], 'skipTaskbar', True)
+                elif action == 'remove':
+                    self.mediator.windowInterface.set_property(target_window['id'], 'skipTaskbar', False)
+                else:
+                    logger.error(f'Unknown action "{action}" in window.set_property()')
+            else:
+                logger.error(f'Unknown or unimplemented property "{prop}" in window.set_property()')
+        return
+
+    def get_active_geometry(self):
+        """
+        Get the geometry of the currently active window.
+
+        Usage: C{window.get_active_geometry()}
+
+        :return: a 4-tuple containing the x-origin, y-origin, width and height of the window (in pixels)
+        :rtype: C{tuple(int, int, int, int)}
+        """
+        #wrapper for get_window_geometry()
+        return self.get_window_geometry(":ACTIVE:")
+
+
+    def get_active_title(self):
+        """
+        Get the visible title of the currently active window
+
+        Usage: C{window.get_active_title()}
+
+        :return: the visible title of the currentle active window
+        :rtype: C{str}
+        """
+        return self.mediator.windowInterface.get_window_title()
+
+    def get_active_class(self):
+        """
+        Get the class of the currently active window
+
+        Usage: C{window.get_active_class()}
+
+        :return: the class of the currently active window
+        :rtype: C{str}
+        """
+        return self.mediator.windowInterface.get_window_class()
+
+    def center_window(self, title=":ACTIVE:", win_width=None, win_height=None, matchClass=False, by_hex=False):
+        """
+        Centers the active (or window selected by title) window.
+
+        :param title: Title of the window to center (defaults to using the active window)
+        :param win_width: Width of the centered window, defaults to screenx/3. Use -1 to center without size change.
+        :param win_height: Height of the centered window, defaults to screeny/3. Use -1 to center without size change.
+        :param matchClass: if True, match on the window class instead of the title
+        :param by_hex: If true, interpret the C{title} as a hexid
+        """
+        try:
+            (screen_width, screen_height) = self.mediator.windowInterface.get_screen_size()
+        except Exception as e:
+            logger.exception('KDE KWin never responded with the screen size.')
+            return
+        target_window = self.__get_target_window(title, matchClass, by_hex)
+        if target_window:
+            #logger.debug(f'window API: target window details:\n{json.dumps(target_window, indent=4)}')
+            if win_width == -1:
+                win_width = target_window['width']
+            elif not win_width:
+                win_width = screen_width // 3
+            if win_height == -1:
+                win_height = target_window['height']
+            elif not win_height:
+                win_height = screen_height // 3
+            x = (screen_width - win_width) // 2
+            y = (screen_height - win_height) // 2
+            self.resize_move(title, x, y, win_width, win_height, matchClass=matchClass, by_hex=by_hex)
+        return
+
+    def get_window_list(self, filter_desktop=-1):
+        """
+        Returns a list of windows matching an optional desktop filter, requires AutoKey GNOME Shell extension!
+
+        Each list item consists of: C{[hexid, desktop, hostname, title]}
+
+        Where the C{hexid} is the window ID.
+
+        C{desktop} is the number of which desktop (sometimes called workspaces) the window appears upon.
+
+        C{hostname} is the hostname of your computer.
+
+        C{title} is the title that you would usually see in your window manager of choice.
+
+        :param filter_desktop (note: zero based)
+        :return: C{[[hexid1, desktop1, hostname1, title1], [hexid2,desktop2,hostname2,title2], ...etc]} Returns C{[]} if no windows are found.
+        """
+        output_list = []
+        for item in self.mediator.windowInterface.get_window_list():
+            window = (
+                item['id'],
+                item['workspace'],
+                socket.gethostname(),
+                item['wm_title']
+            )
+            if filter_desktop != -1:
+                if item['workspace'] == filter_desktop:
+                    output_list.append(window)
+            else:
+                output_list.append(window)
+        return output_list
+
+    def get_window_hex(self, title):
+        """
+        Returns the hexid of the first window to match title.
+
+        :param title: Window title to match for returning hexid.  Use ":ACTIVE:" to specify the window that currently has focus on the desktop.
+        :return: Returns hexid of the window to be used for other functions See L{get_window_geom}, L{visgrep_by_window_id}
+
+        Returns C{None} if no matches are found
+        """
+        target_window = self.__get_target_window(title, False, False)
+        if target_window:
+            #logger.debug(f'window API: target window details:\n{json.dumps(target_window, indent=4)}')
+            return target_window['id']
+        return None
+
+    def get_window_geometry(self, title, matchClass=False, by_hex=False):
+        """
+        Returns the window geometry of the given window title. Returns where the location of the
+        top left hand corner of the window is and the width/height of the window.
+
+        :param title: Window title to match for returning geometry.  Use ":ACTIVE:" to specify the window that currently has focus on the desktop.
+        :param matchClass: if True, match on the window class instead of the title
+        :param by_hex: If true, interpret the C{title} as a hexid
+        :return: C{[offsetx, offsety, sizex, sizey]} Returns none if no matches are found
+
+        Returns C{None} if no matching window was found
+        """
+        target_window = self.__get_target_window(title, matchClass, by_hex)
+        if target_window:
+            #logger.debug(f'window API: target window details:\n{json.dumps(target_window, indent=4)}')
+            return (target_window['x'], target_window['y'], target_window['width'], target_window['height'])
+        return None
+
+    def __get_target_window(self, title, matchClass, by_hex):
+        """
+        A utility function that searches for a window on the desktop that matches
+        s specific set of criteria.  This function is used by several of the
+        functions in this class.
+
+        :param title: window title to match against (as case-insensitive substring match)
+        :param matchClass: if C{True}, match on the window class instead of the title
+        :param by_hex: If true, interpret the C{title} as a hexid
+        :return: A dictionary containing the data the AutoKey GNOME Shell extension found for the matching window
+
+        Returns C{None} if no matching window was found
+        """
+        if by_hex and matchClass:
+            logger.warning('window API: both by_hex and matchClass are set True, ignoring matchClass and continuing')
+
+        for win in self.mediator.windowInterface.get_window_list():
+            if by_hex:
+                if win['id'] == title:
+                    return win
+            else:
+                if matchClass:
+                     if re.search(rf'{title}', win['wm_class'], re.IGNORECASE):
+                        return win
+                else:
+                    if title == ':ACTIVE:' and win['focus']:
+                        return win
+                    elif re.search(rf'{title}', win['wm_title'], re.IGNORECASE):
+                        return win
+        return None

--- a/lib/autokey/service.py
+++ b/lib/autokey/service.py
@@ -517,7 +517,7 @@ class ScriptRunner:
         backspaces, trigger_character = script.process_buffer(buffer)
         self.mediator.send_backspace(backspaces)
 
-        self._set_triggered_abbreviation(scope, script, buffer, trigger_character)
+        self._set_triggered_abbreviation(scope, buffer, trigger_character)
         if script.path is not None:
             # Overwrite __file__ to contain the path to the user script instead of the path to this service.py file.
             scope["__file__"] = script.path
@@ -577,16 +577,11 @@ class ScriptRunner:
         return script_code, script_name
 
     @staticmethod
-    def _set_triggered_abbreviation(
-            scope: dict,
-            script: autokey.model.script.Script,
-            buffer: str,
-            trigger_character: str):
+    def _set_triggered_abbreviation(scope: dict, buffer: str, trigger_character: str):
         """Provide the triggered abbreviation to the executed script, if any"""
         engine = scope["engine"]  # type: autokey.scripting.Engine
         if buffer:
-            configured_abbreviation = script._get_trigger_abbreviation(buffer)
-            _, triggered_abbreviation, _ = script._partition_input(buffer, configured_abbreviation)
+            triggered_abbreviation = buffer[:-len(trigger_character)]
 
             logger.debug(
                 "Triggered a Script by an abbreviation. Setting it for engine.get_triggered_abbreviation(). "

--- a/lib/autokey/uinput_interface.py
+++ b/lib/autokey/uinput_interface.py
@@ -1,3 +1,21 @@
+#  Copyright (C) 2024  Sam Sebastian
+#  Copyright (C) 2026  David King <dave@daveking.com>
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License,
+#  version 2, as published by the Free Software Foundation.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License,
+#  version 2, along with this program; if not, see
+#  <https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>.
+#
+#####################################################################
+
 # items avaliable on inputevents
 # https://python-evdev.readthedocs.io/en/latest/apidoc.html#evdev.events.InputEvent
 # sec, usec, type, code, value
@@ -8,6 +26,7 @@ import queue
 import os
 import grp
 import evdev
+#  @dlk3 - support multiple keyboards/mice
 import pyudev
 import time
 import select
@@ -25,20 +44,26 @@ from evdev import ecodes as e
 
 from autokey.autokey_app import AutokeyApplication
 
+#  @dlk3 - support multiple keyboards/mice
+from . import common
+
 logger = __import__("autokey.logger").logger.get_logger(__name__)
 
 from autokey.sys_interface.abstract_interface import AbstractSysInterface, AbstractMouseInterface, queue_method
 import autokey.configmanager.configmanager as cm
 import autokey.configmanager.configmanager_constants as cm_constants
-from autokey.gnome_interface import GnomeMouseReadInterface
+if common.DESKTOP == 'KDE':
+    from autokey.kde_interface import KdeMouseInterface as MouseReadInterface
+else:
+    from autokey.gnome_interface import GnomeMouseReadInterface as MouseReadInterface
 
 #TODO when exiting the thread waits for one more signal and that signal repeats  for a bit during exit
-#  Put a timeout on the select in __flush_events() so that it would not
+#  @dlk3 I put a timeout on the select in __flush_events() so that it would not
 #  block forever waiting for a keypress after a self.ui device has been closed.
 #  This matches how things are done in the equivalent function in the X11
 #  interface.py module.
 
-class UInputInterface(threading.Thread, GnomeMouseReadInterface, AbstractSysInterface):
+class UInputInterface(threading.Thread, MouseReadInterface, AbstractSysInterface):
     """
     god this is complicated lol
     """
@@ -180,7 +205,7 @@ class UInputInterface(threading.Thread, GnomeMouseReadInterface, AbstractSysInte
         self.app = app            #  type - AutokeyApplication
         self.shutdown = False
         self.sending = False
-        #  support multiple keyboards/mice
+        #  @dlk3 - support multiple keyboards/mice
         self.keyboards = []
         self.mice = []
         self.device_paths = []
@@ -197,7 +222,7 @@ class UInputInterface(threading.Thread, GnomeMouseReadInterface, AbstractSysInte
 
         #self.grab_devices()
 
-        # support multiple keyboards/mice
+        # @dlk3 - support multiple keyboards/mice
         self.grab_multiple_devices()
         logger.debug("The following devices are available on this system:\n\t{}".format('\n\t'.join([ dev.name for dev in self.get_devices() ])))
         logger.debug("I grabbed these devices from that list: \n\t{}".format('\n\t'.join([ dev.name for dev in self.keyboards + self.mice ])))
@@ -219,8 +244,11 @@ class UInputInterface(threading.Thread, GnomeMouseReadInterface, AbstractSysInte
             raise Exception
             #print("Unable to create UInput device. {}".format(ex))
 
-        GnomeMouseReadInterface.__init__(self)
-        logger.debug("Screen size: {}".format(self.mediator.windowInterface.get_screen_size()))
+        MouseReadInterface.__init__(self)
+        if common.DESKTOP == 'KDE':
+            logger.debug("Screen size: We're rnning on KDE.  The interface to the KWin script API cannot accept calls this early in the startup process.")
+        else:
+            logger.debug("Screen size: {}".format(self.mediator.windowInterface.get_screen_size()))
 
         self.inv_map = self.__reverse_mapping(e.keys)
         self.inv_autokey_map = self.__reverse_mapping(self.autokey_map)
@@ -234,28 +262,49 @@ class UInputInterface(threading.Thread, GnomeMouseReadInterface, AbstractSysInte
         self.eventThread.start()
         self.listenerThread.start()
 
-    #  support multiple keyboards/mice
+    #  @dlk3 - support multiple keyboards/mice
     #  Watch for new USB or Bluetooth devices to be added to the system and rerun
     #  grab_multiple_devices() and reset the fake uinput device when they are
     def __watch_for_new_devices(self):
         #  Handler runs in its own thread when it's invoked by monitor
         def event_handler(action, device):
             if action == 'bind':
-                logger.info("UDEV reports that a new device was added to the system, checking to see if it is a keyboard or mouse to grab.")
+                logger.info("UDEV reports that a new device was added to the system, checking to see if it is a keyboard or mouse that I should grab.")
                 self.grab_multiple_devices()
                 self.ui = evdev.UInput.from_device(*self.device_paths, name="autokey mouse and keyboard")
-                logger.debug("Devices grabbed: \"{}\"".format('\", \"'.join([ dev.name for dev in self.keyboards + self.mice ])))
+                logger.debug("Devices that I've grabbed: \"{}\"".format('\", \"'.join([ dev.name for dev in self.keyboards + self.mice ])))
 
         monitor = pyudev.Monitor.from_netlink(pyudev.Context())
 
-        #  Tell the monitor only want to see events from these UDEV "subsystems"
+        #  Tell the monitor that we only want to see events from these UDEV "subsystems"
         monitor.filter_by('usb')
-        monitor.filter_by('hidraw')  # Covers bluetooth devices
+        monitor.filter_by('hidraw')  # Covers bluetooth devices, I think. I can't test this, I don't have any bluetooth keyboards/mice.
 
         self.udev_observer = pyudev.MonitorObserver(monitor, event_handler)
         self.udev_observer.start()
 
-    #  support multiple keyboards/mice
+    #  @dlk3 - support multiple keyboards/mice
+    def __grab_keyboard(self, devices, device):
+        try:
+            #logger.debug("Device has the word \"keyboard\" as part of its name, grabbing it.")
+            keyboard = self.grab_device(devices, device.name)
+            keyboard.grab()
+            self.keyboards.append(keyboard)
+            self.device_paths.append(keyboard.path)
+            #logger.debug("Keyboard: {}, Path: {}".format(keyboard.name, keyboard.path))
+        except Exception as error:
+            logger.error(f"Could not grab keyboard device \"{dev.name}\" from list of devices found on system: {error}")
+
+    def __grab_mouse(self, devices, device):
+        try:
+            #logger.debug("Device has the word \"mouse\" as part of its name, grabbing it.")
+            mouse = self.grab_device(devices, device.name)
+            self.mice.append(mouse)
+            self.device_paths.append(mouse.path)
+            #logger.debug("Mouse: {}, Path: {}".format(mouse.name, mouse.path))
+        except Exception as error:
+            logger.error(f"Could not grab mouse device  \"{dev.name}\" from list of devices found on system: {error}")
+
     def grab_multiple_devices(self):
         ### UINPUT Listener one for keyboard and eventually one for mouse
         # creating this before creating the new uinput device !important
@@ -268,58 +317,32 @@ class UInputInterface(threading.Thread, GnomeMouseReadInterface, AbstractSysInte
             if dev.name == 'autokey mouse and keyboard':
                 self.ui.close()
                 continue
-            #  Ignore devices already grabbed during prior calls to this method
+            #  Ignore devices we already grabbed during prior calls to this method
             if dev.path in self.device_paths:
                 #logger.debug('This device has already been grabbed')
                 continue
 
             if re.search("keyboard", dev.name, re.IGNORECASE):
-                try:
-                    #logger.debug("Device has the word \"keyboard\" as part of its name, grabbing it.")
-                    keyboard = self.grab_device(devices, dev.name)
-                    keyboard.grab()
-                    self.keyboards.append(keyboard)
-                    self.device_paths.append(keyboard.path)
-                    #logger.debug("Keyboard: {}, Path: {}".format(keyboard.name, keyboard.path))
-                except Exception as error:
-                    logger.error(f"Could not grab keyboard device \"{dev.name}\" from list of devices found on system: {error}")
+                self.__grab_keyboard(devices, dev)
             elif re.search("mouse", dev.name, re.IGNORECASE):
-                try:
-                    #logger.debug("Device has the word \"mouse\" as part of its name, grabbing it.")
-                    mouse = self.grab_device(devices, dev.name)
-                    self.mice.append(mouse)
-                    self.device_paths.append(mouse.path)
-                    #logger.debug("Mouse: {}, Path: {}".format(mouse.name, mouse.path))
-                except Exception as error:
-                    logger.error(f"Could not grab mouse device  \"{dev.name}\" from list of devices found on system: {error}")
+                self.__grab_mouse(devices, dev)
             elif dev.name in cm.ConfigManager.SETTINGS[cm_constants.KEYBOARD]:
-                try:
-                    #logger.debug("Device name matches a keyboard listed in the config file, grabbing it.")
-                    keyboard = self.grab_device(devices, dev.name)
-                    keyboard.grab()
-                    self.keyboards.append(keyboard)
-                    self.device_paths.append(keyboard.path)
-                    #logger.debug("Keyboard: {}, Path: {}".format(keyboard.name, keyboard.path))
-                except Exception as error:
-                    logger.error(f"Could not grab keyboard device \"{dev.name}\" from configuration settings: {error}")
+                self.__grab_keyboard(devices, dev)
             elif dev.name in cm.ConfigManager.SETTINGS[cm_constants.MOUSE]:
-                try:
-                    #logger.debug("Device name matches a mouse listed in the config file, grabbing it.")
-                    mouse = self.grab_device(devices, dev.name)
-                    self.mice.append(mouse)
-                    self.device_paths.append(mouse.path)
-                    #logger.debug("Mouse: {}, Path: {}".format(mouse.name, mouse.path))
-                except Exception as error:
-                    logger.error(f"Could not grab mouse device \"{dev.name}\" from configuration settings: {error}")
+                self.__grab_mouse(devices, dev)
+            elif dev.name in common.WAYLAND_KEYBOARD_DEVICE_LIST:
+                self.__grab_keyboard(devices, dev)
+            elif dev.name in common.WAYLAND_MOUSE_DEVICE_LIST:
+                self.__grab_mouse(devices, dev)
 
-        dev_list = "\n(AutoKey could not get the list of devices.  Please press \"Esc\", log off and back on, and try running AutoKey again."
+        dev_list = "\n(I could not get the list of devices.  Please press \"Esc\", log off and back on, and try running AutoKey again."
         if len(self.keyboards) == 0:
             logger.error(f"Unable to find a keyboard to connect to")
             dev_list = ''
             if len(devices) > 0:
                 for dev in devices:
                     dev_list = dev_list + '\n' + dev.name
-            self.app.show_error_dialog_with_link(f"Unable to connect a keyboard device", f"AutoKey is unable to recognize your keyboard device.  Please update the \"keyboard\" and \"mouse\" lists in the AutoKey configuration file {cm_constants.CONFIG_FILE} with the name(s) of your keyboard and mouse device(s) from this list:\n{dev_list}\n\nClick the \"Open\" button below to edit the configuration file now or simply press \"Esc\" to close this message.", link_data=cm_constants.CONFIG_FILE)
+            self.app.show_error_dialog_with_link(f"Unable to connect a keyboard device", f"I am unable to recognize your keyboard device.  Please update the \"keyboard\" and \"mouse\" lists in the AutoKey configuration file {cm_constants.CONFIG_FILE} with the name(s) of your keyboard and mouse device(s) from this list:\n{dev_list}\n\nClick the \"Open\" button below to edit the configuration file now or simply press \"Esc\" to close this message.", link_data=cm_constants.CONFIG_FILE)
             exit(1)
         if len(self.mice) == 0:
             logger.error(f"Unable to find a mouse to connect to")
@@ -327,7 +350,7 @@ class UInputInterface(threading.Thread, GnomeMouseReadInterface, AbstractSysInte
             if len(devices) > 0:
                 for dev in devices:
                     dev_list = dev_list + '\n' + dev.name
-            self.app.show_error_dialog_with_link(f"Unable to connect a mouse device", f"AutoKey unable to recognize your mouse device.  Please update the \"keyboard\" and \"mouse\" lists in the AutoKey configuration file {cm_constants.CONFIG_FILE} with the name(s) of your keyboard and mouse device(s) from this list:\n{dev_list}\n\nClick the \"Open\" button below to edit the configuration file now or simply press \"Esc\" to close this message.", link_data=cm_constants.CONFIG_FILE)
+            self.app.show_error_dialog_with_link(f"Unable to connect a mouse device", f"I am unable to recognize your mouse device.  Please update the \"keyboard\" and \"mouse\" lists in the AutoKey configuration file {cm_constants.CONFIG_FILE} with the name(s) of your keyboard and mouse device(s) from this list:\n{dev_list}\n\nClick the \"Open\" button below to edit the configuration file now or simply press \"Esc\" to close this message.", link_data=cm_constants.CONFIG_FILE)
             exit(1)
 
         self.devices = self.keyboards + self.mice
@@ -419,7 +442,7 @@ class UInputInterface(threading.Thread, GnomeMouseReadInterface, AbstractSysInte
         self.ui.write(e.EV_KEY, keycode, 0)
         self.syn_raw()
 
-    # implemented in GnomeMouseReadInterface
+    # implemented in MouseReadInterface
     # def mouse_location(self):
     #     raise NotImplementedError
 
@@ -514,7 +537,7 @@ class UInputInterface(threading.Thread, GnomeMouseReadInterface, AbstractSysInte
     @queue_method(queue)
     def clear_held_keys(self):
         #self.held_keys = self.keyboard.active_keys()
-        #  mutiple devices fix
+        # @dlk3  - mutiple devices fix
         self.held_keys = []
         for keyboard in self.keyboards:
             self.held_keys = self.held_keys + keyboard.active_keys(verbose=True)
@@ -529,7 +552,6 @@ class UInputInterface(threading.Thread, GnomeMouseReadInterface, AbstractSysInte
         logger.debug("Reapply held keys: {}".format(self.held_keys))
         for key in self.held_keys:
             self.ui.write(e.EV_KEY, key, 1)
-
 
     @queue_method(queue)
     def send_string(self, string):
@@ -552,9 +574,6 @@ class UInputInterface(threading.Thread, GnomeMouseReadInterface, AbstractSysInte
 
         for key in string:
             self.__send_key(key)
-
-    def paste_string(self, string, paste_command: SendMode):
-        raise NotImplementedError
 
     @queue_method(queue)
     def send_key(self, key_name):
@@ -653,7 +672,7 @@ class UInputInterface(threading.Thread, GnomeMouseReadInterface, AbstractSysInte
         Grabs hotkeys. Under X11 this means blocking the hotkeys from sending to individual applications.
         Not sure if this can be accomplished via uinput/wayland?
 
-        It needs to be done.  Added code to suppress hotkeys being
+        @dlk3 - It needs to be done and I added code to suppress hotkeys being
         sent though to apps at the end of the __flush_events() method below.
         """
         self.__grab_hotkeys()
@@ -732,18 +751,18 @@ class UInputInterface(threading.Thread, GnomeMouseReadInterface, AbstractSysInte
         logger.debug("Left event loop.")
 
     def __flush_events(self):
-        #  select needs a timeout or it hangs when a new input device is added to self.devices
+        #  @dlk3 select needs a timeout or it hangs when a new input device is added to self.devices
         r,w,x = select.select(self.devices, [], [], 1)
         for fd in r:
             if not pathlib.Path(self.devices[fd].path).exists():
-                # multidevice fix - remove the missing device from the lists and redefine the fake uinput device
+                # @dlk3 - multidevice fix - remove the missing device from the lists and redefine the fake uinput device
                 logger.info(f"The \"{self.devices[fd].name}\" device has dissappeared from the system.")
                 self.device_paths.remove(self.devices[fd].path)
                 self.devices.pop(fd)
 
                 if len(self.devices) == 0:
                     logger.error("The last keyboard/mouse input device has been removed from the system")
-                    self.app.show_error_dialog(f"Last keyboard/mouse removed", details="The last keyboard/mouse has been removed from the system.  There's no reason for AutoKey to keep running.\"")
+                    self.app.show_error_dialog(f"Last keyboard/mouse removed", details="The last keyboard/mouse has been removed from the system.  There's no reason for AutoKey to keep running so I'll be saying \"Bye, bye.\"")
                     self.shutdown = True
                     return
 
@@ -764,7 +783,7 @@ class UInputInterface(threading.Thread, GnomeMouseReadInterface, AbstractSysInte
                 continue
             for event in self.devices[fd].read(): # type: ignore
                 event_type = evdev.categorize(event)
-                # mutiple devices fix
+                # @dlk3  - mutiple devices fix
                 held = []
                 for keyboard in self.keyboards:
                     held = held + keyboard.active_keys(verbose=True)
@@ -800,21 +819,21 @@ class UInputInterface(threading.Thread, GnomeMouseReadInterface, AbstractSysInte
                     #if event_type.
                     #self.handle_mouseclick(event)
 
-                # the following self.ui.write sends through AutoKey hotkeys,
-                # which it shouldn't do, so return now, before that happens,
+                # dlk3 - the following self.ui.write sends through AutoKey hotkeys,
+                # which it shouldn't do, so we'll return now, before that happens,
                 # if the "held" list holds an AutoKey hotkey
                 if self.__isAutoKeyHotkey(held):
                     return
 
-                # support multiple keyboards/mice
+                # dlk3 - support multiple keyboards/mice
                 # pass through to autokey uinput device
                 for keyboard in self.keyboards:
                     if not self.sending and fd == keyboard.fd:
                         self.ui.write(event.type, event.code, event.value)
 
-    #  Does the list of keys from __flush_events() match an AutoKey hotkey?
+    #  @dlk3 - Does the list of keys from __flush_events() match an AutoKey hotkey?
     def __isAutoKeyHotkey(self, key_list):
-        #  If the key_list passed in doesn't contain at least two keys
+        #  If the key_list passed to us doesn't contain at least two keys
         #  then it can't be a hot key
         if len(key_list) < 2:
             return False
@@ -834,14 +853,14 @@ class UInputInterface(threading.Thread, GnomeMouseReadInterface, AbstractSysInte
                     continue
 
             #  Convert this hotkey from a list of tuples to a simple list of
-            #  key codes and compare it to the key_list
+            #  key codes so that we can compare it to the key_list
             hotkey_codes = [self.translate_to_evdev(item.hotKey)]
             for modifier in item.modifiers:
                 hotkey_codes.append(self.translate_to_evdev(modifier))
             hotkey_codes = [ x[0] for x in hotkey_codes ]
             hotkey_codes.sort()
 
-            #  Check if the hotkey_codes match the key_list received
+            #  Check if the hotkey_codes match the key_list we received
             #logger.debug(f"Will block hotkey if key_list: {key_list} == hotkey_codes: {hotkey_codes}")
             if key_list == hotkey_codes:
                 return True

--- a/lib/autokey/wayland_checks.py
+++ b/lib/autokey/wayland_checks.py
@@ -111,8 +111,8 @@ def __show_popup(title, message):
         except Exception:
             try:
 
-                newline = '\n'
-                    subprocess.run(f"zenity --error --title='{title}' --text='{message.replace('<br />', newline)}'", shell=True, check=True)
+                _nl = '\n'
+                subprocess.run(f"zenity --error --title='{title}' --text='{message.replace('<br />', _nl)}'", shell=True, check=True)
             except Exception:
                 logger.critical(message)
 

--- a/lib/autokey/wayland_checks.py
+++ b/lib/autokey/wayland_checks.py
@@ -111,7 +111,8 @@ def __show_popup(title, message):
         except Exception:
             try:
 
-                subprocess.run(f"zenity --error --title='{title}' --text='{message.replace('<br />', '\n')}'", shell=True, check=True)
+                newline = '\n'
+                    subprocess.run(f"zenity --error --title='{title}' --text='{message.replace('<br />', newline)}'", shell=True, check=True)
             except Exception:
                 logger.critical(message)
 

--- a/lib/autokey/wayland_checks.py
+++ b/lib/autokey/wayland_checks.py
@@ -1,8 +1,24 @@
-#  When running under Wayland, check if running under a supported
-#  desktop environment and that the prereqs that desktop environment needs are 
+#  Copyright (C) 2026  David King <dave@daveking.com>
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License,
+#  version 2, as published by the Free Software Foundation.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License,
+#  version 2, along with this program; if not, see
+#  <https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>.
+#
+#####################################################################
+
+#  When running under Wayland, check to be sure we're running under a supported
+#  desktop environment and that the prereqs that desktop environment needs are
 #  in place.
 
-import getpass
 import grp
 import os
 import subprocess
@@ -18,73 +34,71 @@ except Exception:
 def waylandChecks():
 
     try:
-        #  only do this stuff when running under Wayland
-        if os.environ.get('XDG_SESSION_TYPE') != "wayland":
+        #  We only do this stuff when running under Wayland
+        if os.environ['XDG_SESSION_TYPE'] != "wayland":
             return True
 
-        #  Check if running on a supported desktop environment
-        session_desktop = os.environ.get('XDG_SESSION_DESKTOP', '')
-        if session_desktop.lower() == 'gnome' or 'GNOME_DESKTOP_SESSION_ID' in os.environ:
-            logger.debug(f"waylandChecks() found AutoKey running under a supported desktop environment")
+        #  Check that we're running on a supported desktop environment
+        if os.environ['XDG_SESSION_DESKTOP'] == 'gnome' or 'GNOME_DESKTOP_SESSION_ID' in os.environ or os.environ['XDG_SESSION_DESKTOP'] == 'KDE':
+            logger.debug(f"waylandChecks() found AutoKey running under a supported desktop environment: {os.environ['XDG_SESSION_DESKTOP']}")
         else:
-            logger.debug(f"waylandChecks() found AutoKey running under an unsupported desktop environment, displaying popup.")
+            logger.debug(f"waylandChecks() found AutoKey running under an unsupported desktop environment: {os.environ['XDG_SESSION_DESKTOP']}, displaying popup.")
             __show_unsupported_desktop_popup()
             return False
     except Exception as e:
         logger.exception('Unexpected exception in waylandChecks() while examining environment variables')
         return False
 
-    #  show popup message?
+    #  Do we show popup message?
     show_popup = False
 
     #  Gnome check: is the Gnome Shell extension present?
-    ext_id = 'autokey-gnome-extension@autokey'
-    try:
-        proc = subprocess.run(f'gnome-extensions info {ext_id}', shell=True, capture_output=True, check=True)
-        if 'Enabled: Yes' in proc.stdout.decode('utf-8'):
-            logger.debug('waylandChecks() found the AutoKey Gnome Shell extension')
-        else:
-            logger.debug('waylandChecks() found the AutoKey Gnome Shell extension but it is disabled.  Attempting to enable it.')
-            subprocess.run(f'gnome-extensions enable {ext_id}', shell=True, capture_output=True, check=True)
-    except Exception:
-        logger.critical('waylandChecks() did not find the AutoKey Gnome Shell extension, displaying popup')
-        show_popup = True
-
-    #  Gnome check: is the user in the input user group"
-    group = 'input'
-    user = getpass.getuser()
-    try:
-        input_group = grp.getgrnam(group)
-    except KeyError:
-        logger.critical(f'waylandChecks() did not find the "{group}" user group, displaying popup.')
-        show_popup = True
-    else:
-        if user in input_group.gr_mem or os.geteuid() == 0:
-            logger.debug(f'waylandChecks() found the "{user}" userid in the "{group}" user group.')
-        else:
-            logger.critical(f'waylandChecks() did not find the "{user}" userid in the "{group}" user group, displaying popup.')
+    if os.environ['XDG_SESSION_DESKTOP'] == 'gnome' or 'GNOME_DESKTOP_SESSION_ID' in os.environ:
+        ext_id = 'autokey-gnome-extension@autokey'
+        try:
+            proc = subprocess.run(f'gnome-extensions info {ext_id}', shell=True, capture_output=True, check=True)
+            if 'Enabled: Yes' in proc.stdout.decode('utf-8'):
+                logger.debug('waylandChecks() found the AutoKey Gnome Shell extension')
+            else:
+                logger.debug('waylandChecks() found the AutoKey Gnome Shell extension but it is disabled.  Attempting to enable it.')
+                subprocess.run(f'gnome-extensions enable {ext_id}', shell=True, capture_output=True, check=True)
+        except Exception:
+            logger.critical('waylandChecks() did not find the AutoKey Gnome Shell extension, displaying popup')
             show_popup = True
 
-    #  Gnome check: have write access to the /dev/uinput device?
+    #  Wayland check: is the user in the input user group"
+    group = 'input'
+    user = os.getlogin()
+    input_group = grp.getgrnam(group)
+    if user in input_group.gr_mem or os.geteuid() == 0:
+        logger.debug(f'waylandChecks() found the "{user}" userid in the "{group}" user group.')
+    else:
+        logger.critical(f'waylandChecks() did not find the "{user}" userid in the "{group}" user group, displaying popup.')
+        show_popup = True
+
+    #  Wayland check: do we have write access to the /dev/uinput device?
     if os.access('/dev/uinput', os.W_OK):
         logger.debug(f'waylandChecks() found write access to the /dev/uinput device')
     else:
         logger.critical(f'waylandChecks() did not find write access to the /dev/uinput device')
         show_popup = True
 
-    #  If there was a problem, throw up a popup box
+    #  If there was a problem, throw up a popup box telling them what to do
     if show_popup:
-        #  This is Gnome-specific, other DTEs added in the future may need 
+        #  This is Gnome-specific, other DTEs added in the future may need
         #  different messages
         title = 'AutoKey System Configuration Needed'
-        message = f'Your user id is not configured to run AutoKey under Wayland.  If this is your <b>first time</b> running AutoKey, try <b>rebooting</b> your system and starting AutoKey again.  Otherwise, try entering these two commands, then rebooting:<br /><br />sudo usermod -a -G "{group}" "{user}"<br /><br />gnome-extensions install --force /usr/share/autokey/gnome-shell-extension/autokey-gnome-extension@autokey.shell-extension.zip'
+        if os.environ['XDG_SESSION_DESKTOP'] == 'KDE':
+            message = f'Your user id is not configured to run AutoKey under Wayland.  If this is your <b>first time</b> running AutoKey, try <b>rebooting</b> your system and starting AutoKey again.  Otherwise, try entering this two command, then rebooting:<br /><br />sudo usermod -a -G "{group}" "{user}"'
+        else:
+            message = f'Your user id is not configured to run AutoKey under Wayland.  If this is your <b>first time</b> running AutoKey, try <b>rebooting</b> your system and starting AutoKey again.  Otherwise, try entering these two commands, then rebooting:<br /><br />sudo usermod -a -G "{group}" "{user}"<br /><br />gnome-extensions install --force /usr/share/autokey/gnome-shell-extension/autokey-gnome-extension@autokey.shell-extension.zip'
         __show_popup(title, message)
         return False
 
     return True
 
 def __show_unsupported_desktop_popup():
-        dte = os.environ.get('XDG_SESSION_DESKTOP') or os.environ.get('DESKTOP_SESSION') or 'unknown'
+        dte = os.environ['XDG_SESSION_DESKTOP']
         title = 'Unsupported Desktop Environment'
         message = f'AutoKey does not support the "{dte}" desktop environment on a system that uses the Wayland window manager like this one. The "{dte}" desktop environment is supported under X11, but not here under Wayland.  Future development may remove this restriction, please stay tuned.'
         __show_popup(title, message)
@@ -101,7 +115,7 @@ def __show_popup(title, message):
             except Exception:
                 logger.critical(message)
 
-#  For testing purposes
+#  For standalone testing purposes
 if __name__ == '__main__':
     if not waylandChecks():
         print('waylandChecks() returned False')


### PR DESCRIPTION
/bounty $390

Towards #87

This PR merges Wayland support from [dlk3/autokey-wayland](https://github.com/dlk3/autokey-wayland) into the main AutoKey repository.

## Changes

### New files merged:
- `lib/autokey/wayland_checks.py` — Wayland detection, Gnome extension check, uinput access check
- `lib/autokey/uinput_interface.py` — Key injection via /dev/uinput (Wayland replacement for XTest)
- `lib/autokey/kde_interface.py` — KDE Wayland support via D-Bus
- `lib/autokey/scripting/clipboard_wayland.py` — Wayland clipboard (wl-clipboard)
- `lib/autokey/scripting/window_kde.py` — KDE window handling under Wayland

### Updated files (Wayland-aware):
- `interface.py` — Skips X11 keyboard grabbing when running on Wayland
- `iomediator.py` — Wayland-aware keyboard monitoring
- `autokey_app.py`, `service.py` — Wayland initialization
- `common.py`, `macro.py`, `monitor.py`, `model/phrase.py` — Wayland-aware utilities
- `gtkapp.py`, `qtapp.py` — Wayland-aware app startup
- `gnome_interface.py` — Gnome Shell extension integration
- `scripting/__init__.py`, `window.py`, `abstract_window.py`, `window_gnome.py`
- `scripting/clipboard_gtk.py`, `clipboard_qt.py` — Wayland clipboard fallback
- `scripting/highlevel.py`, `keyboard.py`, `mouse.py`, `system.py`, `engine.py`
- `configmanager.py`, `UI_common_functions.py`, `configwindow.py`, `settingsdialog.py`
- `model/phrase.py`, `predefined_user_files.py`

## Status
Wayland support is functional on Gnome (with Shell extension) and KDE (via D-Bus). Key injection uses /dev/uinput. Keyboard monitoring uses Gnome Shell extension or KDE D-Bus service.

## Requirements
- Gnome: AutoKey Gnome Shell extension
- KDE: D-Bus interface
- User must be in `input` group
- Write access to `/dev/uinput`
