### PR TITLE
Fix imghdr incompatibility for Python 3.13

### DIFF
--- a/lib/autokey/scripting/highlevel.py
+++ b/lib/autokey/scripting/highlevel.py
@@ -6,7 +6,6 @@ import time
 import os
 import subprocess
 import tempfile
-import imghdr
 import struct
 
 
@@ -72,9 +71,10 @@ def get_png_dim(filepath: str) -> int:
     @returns: (width, height).
     @raise Exception: Raised if the file is not a png
     """
-    if not imghdr.what(filepath) == 'png':
+    with open(filepath, 'rb') as image_file:
+        head = image_file.read(24)
+    if not head.startswith(b'\x89PNG\r\n\x1a\n'):
         raise Exception("not PNG")
-    head = open(filepath, 'rb').read(24)
     return struct.unpack('!II', head[16:24])
 
 
@@ -166,4 +166,3 @@ def acknowledge_gnome_notification():
     mouse_click(LEFT)
     time.sleep(.2)
     mouse_move(x0, y0)
-

--- a/tests/test_highlevel.py
+++ b/tests/test_highlevel.py
@@ -1,0 +1,32 @@
+import importlib.util
+import pathlib
+
+import pytest
+
+
+def load_highlevel_module():
+    module_path = pathlib.Path(__file__).parents[1] / "lib" / "autokey" / "scripting" / "highlevel.py"
+    spec = importlib.util.spec_from_file_location("highlevel", module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_get_png_dim_reads_png_size(tmp_path):
+    png_path = tmp_path / "pattern.png"
+    png_path.write_bytes(
+        b"\x89PNG\r\n\x1a\n"
+        b"\x00\x00\x00\rIHDR"
+        b"\x00\x00\x00\x10"
+        b"\x00\x00\x00 "
+    )
+
+    assert load_highlevel_module().get_png_dim(str(png_path)) == (16, 32)
+
+
+def test_get_png_dim_rejects_non_png(tmp_path):
+    text_path = tmp_path / "pattern.txt"
+    text_path.write_text("not a png")
+
+    with pytest.raises(Exception, match="not PNG"):
+        load_highlevel_module().get_png_dim(str(text_path))


### PR DESCRIPTION
This PR fixes the compatibility issue with `imghdr` which was deprecated and removed in recent Python versions (such as Python 3.13). The image type detection logic has been updated to use a modern, robust alternative in `highlevel.py`, and the corresponding tests have been updated and verified locally.

Contribution Note
I'm glad to contribute this fix to help keep AutoKey compatible with modern Python environments. If the project currently participates in any developer bounty, Polar, or Open Collective reward programs for contributors, please let me know how I can link this contribution. Thank you!