### PR TITLE
fix(gtkui): save abbreviation text when cell editing is cancelled

### DIFF
--- a/lib/autokey/gtkui/dialogs.py
+++ b/lib/autokey/gtkui/dialogs.py
@@ -232,6 +232,7 @@ class AbbrSettingsDialog(DialogBase):
         textRenderer.set_property("editable", True)
         textRenderer.connect("edited", self.on_cell_modified)
         textRenderer.connect("editing-canceled", self.on_cell_editing_cancelled)
+        textRenderer.connect("editing-started", self.on_cell_editing_started)
         column1.pack_end(textRenderer, True)
         column1.add_attribute(textRenderer, "text", 0)
         column1.set_sizing(Gtk.TreeViewColumnSizing.FIXED)
@@ -363,10 +364,20 @@ class AbbrSettingsDialog(DialogBase):
 
     # Signal handlers
 
+    def on_cell_editing_started(self, renderer, editable, path, data=None):
+        self._current_abbr_editable = editable
+
     def on_cell_editing_cancelled(self, renderer, data=None):
         model, curIter = self.abbrList.get_selection().get_selected()
         oldText = model.get_value(curIter, 0) or ""
-        self.on_cell_modified(renderer, None, oldText)
+        newText = None
+        if hasattr(self, '_current_abbr_editable') and self._current_abbr_editable is not None:
+            newText = self._current_abbr_editable.get_text()
+            self._current_abbr_editable = None
+        if newText is not None and newText != oldText and not EMPTY_FIELD_REGEX.match(newText):
+            model.set(curIter, 0, newText)
+        elif EMPTY_FIELD_REGEX.match(newText or "") and EMPTY_FIELD_REGEX.match(oldText):
+            self.on_removeButton_clicked(renderer)
 
     def on_cell_modified(self, renderer, path, newText, data=None):
         model, curIter = self.abbrList.get_selection().get_selected()


### PR DESCRIPTION
## Summary

Fixes #667 - Setting an abbreviation still requires pressing Enter.

## Problem

When editing an abbreviation in the Abbreviation Settings dialog, pressing Enter triggers the "edited" signal which saves the new text. However, clicking away or pressing Tab triggers the "editing-canceled" signal, which was restoring the OLD text — losing the user's work.

## Fix

- Connect the "editing-started" signal to capture a reference to the GtkEntry editable widget
- In the "editing-cancelled" handler, read the current text from the editable and commit it to the model if it's non-empty and different from the original
- Preserves existing behavior for empty/whitespace-only fields (removes the row)

## Test plan

- [ ] Open abbreviation settings for any phrase/script
- [ ] Edit an existing abbreviation, click away (or press Tab) — text is saved
- [ ] Add new abbreviation, type text, click away — text is saved
- [ ] Edit abbreviation to empty, click away — row is removed
- [ ] Press Escape to cancel editing — does not save (GTK default)