### PR TITLE
Fix pkg_resources launcher warning

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,7 @@ PR #1076 Changes
  
 Important misc changes
 ----------------------
+- Replace the GTK and Qt setuptools-generated launchers with explicit scripts to avoid the deprecated ``pkg_resources`` entry-point wrapper. Fixes issue `#1047 <https://github.com/autokey/autokey/issues/1047>`__.
 - Bump action versions in pages.yml to satisfy part of issue #963.
 - Bump action versions in build.yml to satisfy part of issue #963.
 - Bump action versions in python-test.yml to satisfy part of issue #963.

--- a/autokey-gtk
+++ b/autokey-gtk
@@ -1,0 +1,7 @@
+#!/usr/bin/env python3
+
+from autokey.gtkui.__main__ import main
+
+
+if __name__ == "__main__":
+    main()

--- a/autokey-qt
+++ b/autokey-qt
@@ -1,0 +1,7 @@
+#!/usr/bin/env python3
+
+from autokey.qtui.__main__ import main
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/autokey/qtui/__main__.py
+++ b/lib/autokey/qtui/__main__.py
@@ -30,8 +30,9 @@ try:
 except KeyError:
     pass
 
-if __name__ == '__main__':
-    # When invoked by the setup.py generated launcher, __name__ is set to "autokey.qtui.__main__", so
-    # this is only executed if invoked directly from the source directory as "python3 -m [lib.]autokey.qtui"
-    # The setup.py launcher directly calls Application() after importing
+def main():
     Application()
+
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ try:
     from setuptools import setup
 except ImportError:
     print("Autokey needs setuptools in order to build. Install it with your package"
-          "manager (python-setuptools) or via pip (pip install setuptools)")
+          "manager (python3-setuptools) or via pip (python3 -m pip install setuptools)")
     sys.exit(1)
 else:
     import setuptools.command.build_py
@@ -182,12 +182,10 @@ setup(
                 ],
     entry_points={
         'console_scripts': [
-            'autokey-gtk=autokey.gtkui.__main__:main',
-            'autokey-qt=autokey.qtui.__main__:Application',
             'autokey-headless=autokey.headless_app:main',
         ]
     },
-    scripts=['autokey-run', 'autokey-shell'],
+    scripts=['autokey-gtk', 'autokey-qt', 'autokey-run', 'autokey-shell'],
     # Minimal installation pre-requisite python packages.
     # Some are not included here because they should be installed
     # through the system package manager, not pip.


### PR DESCRIPTION
## Summary
- Replace setuptools-generated `console_scripts` for `autokey-gtk` and `autokey-qt` with explicit script files.
- Keep the existing `autokey-headless` console entry point on `develop`.
- Add a `main()` wrapper for the Qt entry point so both launch scripts call package code directly.
- Add a `CHANGELOG.rst` entry and update the missing-setuptools hint to use `python3 -m pip install setuptools`.

## Why
Older setuptools-generated entry point wrappers import `pkg_resources.load_entry_point`, which is the warning reported in #1047. Installing explicit scripts avoids generating that wrapper for the GUI commands.

Closes #1047

## Verification
- `python -m py_compile setup.py autokey-gtk autokey-qt lib/autokey/qtui/__main__.py lib/autokey/gtkui/__main__.py`
- `python setup.py --name`
- `python setup.py build_scripts`, then confirmed the generated scripts contain no `pkg_resources` or `load_entry_point` references

This repo mentions Opire on the issue; if this maintenance fix is helpful and the project wants to fund or tip it there, I can follow that flow.