### PR TITLE
fix: remove leftover debug print() calls in UnityLauncher.rebuild_menu

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -699,3 +699,8 @@ Modified the launcher and other files to allow for editable installs ("pip insta
 Added an "about" dialog for the Python 3 port.
 
 Changed hyperlink for bug reports.
+
+PR #1168 Changes
+----------------
+
+- Remove leftover debug `print()` calls from `UnityLauncher.rebuild_menu` in the GTK notifier that spammed the terminal on every menu rebuild.

--- a/lib/autokey/gtkui/notifier.py
+++ b/lib/autokey/gtkui/notifier.py
@@ -198,16 +198,13 @@ class UnityLauncher(IndicatorNotifier):
         
     def rebuild_menu(self):
         IndicatorNotifier.rebuild_menu(self)
-        print(threading.currentThread().name)
-        
+
         #try:
         from gi.repository import Unity, Dbusmenu
         HAVE_UNITY = True
-        print("have unity")
         #except ImportError:
         #    return
 
-        print("rebuild unity menu")
         self.launcher = Unity.LauncherEntry.get_for_desktop_id ("autokey-gtk.desktop")   
     
         # Main Menu items


### PR DESCRIPTION
Found three leftover debug `print()` calls in `lib/autokey/gtkui/notifier.py` inside `UnityLauncher.rebuild_menu`:

```python
print(threading.currentThread().name)
print("have unity")
print("rebuild unity menu")
```

These are clearly debug leftovers — they spam the terminal every time the
indicator menu is rebuilt. The first one also leaks the current thread name
to stdout on a UI operation.

**Before:**
```python
def rebuild_menu(self):
    IndicatorNotifier.rebuild_menu(self)
    print(threading.currentThread().name)
    from gi.repository import Unity, Dbusmenu
    HAVE_UNITY = True
    print("have unity")
    print("rebuild unity menu")
    self.launcher = Unity.LauncherEntry.get_for_desktop_id ("autokey-gtk.desktop")
```

**After:**
```python
def rebuild_menu(self):
    IndicatorNotifier.rebuild_menu(self)
    from gi.repository import Unity, Dbusmenu
    HAVE_UNITY = True
    self.launcher = Unity.LauncherEntry.get_for_desktop_id ("autokey-gtk.desktop")
```

No control flow or logging is changed — the prints had no effect on behavior.

— Sent via @AmSach bot