### PR TITLE
fix: read NumLock and CapsLock state from the X server

### DIFF
--- a/lib/autokey/interface.py
+++ b/lib/autokey/interface.py
@@ -252,6 +252,35 @@ class XWindowInterface(AbstractWindowInterface):
             return None
 
 
+def query_lock_state(display, root_window):
+    """
+    Query the current lock state of CapsLock and NumLock.
+
+    The core GetKeyboardControl led_mask is unreliable under XKB,
+    which is the default on modern distributions. Query the modifier
+    mapping and the current pointer state instead.
+
+    @param display: The X display to query.
+    @param root_window: The root window of the display.
+    @return: A tuple (capslock_on, numlock_on) with the current states.
+    """
+    numlock_on = capslock_on = False
+    numlock_keycode = display.keysym_to_keycode(XK.XK_Num_Lock)
+    capslock_keycode = display.keysym_to_keycode(XK.XK_Caps_Lock)
+    if numlock_keycode or capslock_keycode:
+        modifier_keycodes = display.get_modifier_mapping()
+        try:
+            pointer_mask = root_window.query_pointer().mask
+        except error.XError:
+            pointer_mask = 0
+        for index, keycodes in enumerate(modifier_keycodes):
+            if numlock_keycode and numlock_keycode in keycodes:
+                numlock_on = bool(pointer_mask & (1 << index))
+            if capslock_keycode and capslock_keycode in keycodes:
+                capslock_on = bool(pointer_mask & (1 << index))
+    return capslock_on, numlock_on
+
+
 class XInterfaceBase(threading.Thread, AbstractMouseInterface):
     """
     Encapsulates the common functionality for the two X interface classes.
@@ -570,9 +599,16 @@ class XInterfaceBase(threading.Thread, AbstractMouseInterface):
         self.join()
 
     def __set_lock_keys_state(self):
-        ledMask = self.localDisplay.get_keyboard_control().led_mask
-        self.mediator.set_modifier_state(Key.CAPSLOCK, (ledMask & CAPSLOCK_LEDMASK) != 0)
-        self.mediator.set_modifier_state(Key.NUMLOCK, (ledMask & NUMLOCK_LEDMASK) != 0)
+        try:
+            capslock_on, numlock_on = query_lock_state(
+                self.localDisplay, self.rootWindow)
+        except Exception:
+            logger.exception("Failed to query lock state; falling back to LED mask")
+            ledMask = self.localDisplay.get_keyboard_control().led_mask
+            capslock_on = (ledMask & CAPSLOCK_LEDMASK) != 0
+            numlock_on = (ledMask & NUMLOCK_LEDMASK) != 0
+        self.mediator.set_modifier_state(Key.CAPSLOCK, capslock_on)
+        self.mediator.set_modifier_state(Key.NUMLOCK, numlock_on)
 
     def __eventLoop(self):
         while True:

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -139,3 +139,129 @@ class TestXrecord():
             # Need to cancel early. But cancel in tearDown as well in case this test fails.
             self.cancel()
         assert_that(self.ec.get_result(), is_(equal_to(expected)), failmsg)
+
+
+# Tests for the lock-state query helper (query_lock_state) added for #1177.
+# These use fake display objects. They do not need an X server.
+from Xlib.error import XError
+from autokey.interface import query_lock_state
+
+XK_Num_Lock = 0xff7f
+XK_Caps_Lock = 0xffe5
+
+
+class FakePointerState:
+    def __init__(self, mask):
+        self.mask = mask
+
+
+class FakeRootWindow:
+    def __init__(self, mask, error=False):
+        self._mask = mask
+        self._error = error
+
+    def query_pointer(self):
+        if self._error:
+            raise XError(None, b"\x00\x01\x00\x00" + b"\x00" * 28)
+        return FakePointerState(self._mask)
+
+
+class FakeDisplay:
+    """
+    A minimal fake of the python-xlib Display interface.
+    """
+
+    def __init__(self, keycodes, modifier_mapping):
+        # keycodes: dict keysym -> keycode
+        # modifier_mapping: list of eight lists of keycodes
+        self._keycodes = keycodes
+        self._modifier_mapping = modifier_mapping
+
+    def keysym_to_keycode(self, keysym):
+        return self._keycodes.get(keysym, 0)
+
+    def get_modifier_mapping(self):
+        return self._modifier_mapping
+
+
+def make_display(numlock_code=66, capslock_code=77, numlock_modifier=4,
+                 capslock_modifier=1):
+    # Standard layout: NumLock on Mod2 (index 4), CapsLock on Lock (index 1).
+    keycodes = {}
+    if numlock_code:
+        keycodes[XK_Num_Lock] = numlock_code
+    if capslock_code:
+        keycodes[XK_Caps_Lock] = capslock_code
+    mapping = [[] for _ in range(8)]
+    if numlock_code:
+        mapping[numlock_modifier].append(numlock_code)
+    if capslock_code:
+        mapping[capslock_modifier].append(capslock_code)
+    return FakeDisplay(keycodes, mapping)
+
+
+def test_numlock_on():
+    display = make_display()
+    root = FakeRootWindow(mask=1 << 4)
+    capslock_on, numlock_on = query_lock_state(display, root)
+    assert_that(capslock_on, is_(False))
+    assert_that(numlock_on, is_(True))
+
+
+def test_numlock_off():
+    display = make_display()
+    root = FakeRootWindow(mask=0)
+    capslock_on, numlock_on = query_lock_state(display, root)
+    assert_that(capslock_on, is_(False))
+    assert_that(numlock_on, is_(False))
+
+
+def test_capslock_on():
+    display = make_display()
+    root = FakeRootWindow(mask=1 << 1)
+    capslock_on, numlock_on = query_lock_state(display, root)
+    assert_that(capslock_on, is_(True))
+    assert_that(numlock_on, is_(False))
+
+
+def test_both_locks_on():
+    display = make_display()
+    root = FakeRootWindow(mask=(1 << 1) | (1 << 4))
+    capslock_on, numlock_on = query_lock_state(display, root)
+    assert_that(capslock_on, is_(True))
+    assert_that(numlock_on, is_(True))
+
+
+def test_non_standard_modifier_index():
+    # NumLock bound to Mod3 (index 5) instead of the usual Mod2.
+    display = make_display(numlock_modifier=5)
+    root = FakeRootWindow(mask=1 << 5)
+    capslock_on, numlock_on = query_lock_state(display, root)
+    assert_that(numlock_on, is_(True))
+    assert_that(capslock_on, is_(False))
+
+
+def test_keycode_absent_from_mapping():
+    # NumLock keycode known but bound to no modifier: state stays off.
+    display = make_display()
+    display._modifier_mapping[4] = []
+    root = FakeRootWindow(mask=1 << 4)
+    capslock_on, numlock_on = query_lock_state(display, root)
+    assert_that(capslock_on, is_(False))
+    assert_that(numlock_on, is_(False))
+
+
+def test_no_numlock_key():
+    display = make_display(numlock_code=0)
+    root = FakeRootWindow(mask=1 << 4)
+    capslock_on, numlock_on = query_lock_state(display, root)
+    assert_that(capslock_on, is_(False))
+    assert_that(numlock_on, is_(False))
+
+
+def test_pointer_query_error_masks_state():
+    display = make_display()
+    root = FakeRootWindow(mask=1 << 4, error=True)
+    capslock_on, numlock_on = query_lock_state(display, root)
+    assert_that(capslock_on, is_(False))
+    assert_that(numlock_on, is_(False))


### PR DESCRIPTION
Fixes #1177

## Problem

Phrase triggers created with numpad digits (example: abbreviation `1/2`) expand when typed on the main keyboard, but never when typed on the numpad. AutoKey sees the numpad digits as directional keys.

## Root cause

`XInterfaceBase.__init__` initialized the tracked NumLock/CapsLock state from the core X protocol `led_mask`:

```python
ledMask = self.localDisplay.get_keyboard_control().led_mask
```

Under XKB, which is the default keyboard extension on every modern distribution, the core `led_mask` frequently reads `0` while the NumLock LED is on. AutoKey then tracks NumLock as off, `lookup_string()` skips the `XK_TO_AK_NUMLOCKED` branch, and numpad digits decode to the directional names (`Key.NP_END`, `Key.NP_DOWN`, ...). Those names are non-simple keys, so `__updateStack()` clears the input stack and no abbreviation matches.

## Fix

Query the true lock state from the X server instead of trusting the LED mask:

- `keysym_to_keycode(XK_Num_Lock)` / `keysym_to_keycode(XK_Caps_Lock)` locate the lock keys.
- `get_modifier_mapping()` maps each modifier index to its keycodes.
- `query_pointer().mask` on the root window reports the current locked-modifier state.
- The LED-mask path is preserved as a fallback.

The new `query_lock_state()` helper is pure and unit-testable without an X server.

## Tests

- 8 new unit tests in `tests/test_interface.py` (fake display, no X server): both locks on/off, non-standard modifier index, keycode absent from mapping, XError on the pointer query.
- Full suite: 327 passed vs 319 baseline, same 10 pre-existing environmental failures, zero new failures.

Author: RawNuke