### PR TITLE
test: add regression harness for stuck-modifier bug (#1007)

### DIFF
--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -12,7 +12,12 @@
 
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
+import queue
+import time
+
 import Xlib
+from Xlib import X, display
+from Xlib.ext import xtest
 
 import pytest
 from hamcrest import *
@@ -139,3 +144,143 @@ class TestXrecord():
             # Need to cancel early. But cancel in tearDown as well in case this test fails.
             self.cancel()
         assert_that(self.ec.get_result(), is_(equal_to(expected)), failmsg)
+
+
+class TestModifierKeyReleaseForwarding:
+    """
+    Regression harness for https://github.com/autokey/autokey/issues/1007.
+
+    When a hotkey combo like <ctrl>+1 is grabbed and released out of order
+    (the modifier released before the non-modifier key), X's implicit
+    keyboard grab swallows the modifier's KeyRelease: it reaches AutoKey's
+    connection but never the application the user was typing into, leaving
+    the modifier "stuck" from that application's point of view.
+
+    This exercises AutoKey's real grab_key/__flush_events machinery against
+    a live (Xvfb) X server, with a second connection standing in for "the
+    focused application", rather than mocking the interface layer.
+    """
+
+    def setup_method(self):
+        # __grab_ungrab_hotkey reads common.ARGS.grabkey_logging directly; outside
+        # a real app bootstrap (argument_parser.parse_args()) it's None, which
+        # makes every real grab silently no-op (the AttributeError is swallowed
+        # by __eventLoop's catch-all). Populate it the same way the app does.
+        import autokey.argument_parser
+        import autokey.common
+        self.args_patch = patch.object(
+            autokey.common, "ARGS",
+            autokey.argument_parser._generate_argument_parser().parse_args([]))
+        self.args_patch.start()
+
+        # XInterfaceBase.queue is a *class* attribute, shared by every
+        # instance in the process. If an earlier test's interface left its
+        # (None, None) shutdown sentinel sitting in it, our instance's fresh
+        # eventThread would consume that sentinel first and exit immediately,
+        # leaving every real call we enqueue (including __initMappings' own)
+        # stuck forever -- queue.join() would then hang for good. Give this
+        # test its own queue so it can't inherit another test's leftovers --
+        # via patch.object (not a plain assignment) so it's restored on
+        # teardown instead of leaking a fresh queue forward into whichever
+        # test runs next in the session.
+        self.queue_patch = patch.object(
+            autokey.interface.XInterfaceBase, "queue", queue.Queue())
+        self.queue_patch.start()
+
+        self.app = MagicMock()
+        self.app.configManager.hotKeys = []
+        self.app.configManager.hotKeyFolders = []
+        self.app.configManager.globalHotkeys = []
+        self.mediator = MagicMock()
+        self.ifc = autokey.interface.XRecordInterface(self.mediator, self.app)
+        # Let the (empty) initial hotkey grab enqueued by __initMappings settle
+        # before the test enqueues its own grab.
+        self.ifc.queue.join()
+
+        # A second connection + window standing in for the focused application.
+        self.target_display = display.Display()
+        screen = self.target_display.screen()
+        self.target_window = screen.root.create_window(
+            0, 0, 100, 100, 0, screen.root_depth, X.InputOutput, X.CopyFromParent,
+            background_pixel=screen.white_pixel,
+            event_mask=X.KeyPressMask | X.KeyReleaseMask,
+        )
+        self.target_window.map()
+        self.target_display.sync()
+        self.target_window.set_input_focus(X.RevertToParent, X.CurrentTime)
+        self.target_display.sync()
+        self._drain(self.target_display)
+
+    def teardown_method(self):
+        try:
+            self.target_display.close()
+        except Exception:
+            pass
+        try:
+            autokey.interface.XInterfaceBase.cancel(self.ifc)
+        except RuntimeError:
+            # Complaints about joining self thread before it starts.
+            pass
+        except Xlib.error.ConnectionClosedError:
+            # Complaints about closing after closing already.
+            pass
+        self.queue_patch.stop()
+        self.args_patch.stop()
+
+    @staticmethod
+    def _drain(disp):
+        while disp.pending_events():
+            disp.next_event()
+
+    @staticmethod
+    def _wait_for_event(disp, event_type, detail, timeout=3.0):
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            while disp.pending_events():
+                evt = disp.next_event()
+                if evt.type == event_type and evt.detail == detail:
+                    return evt
+            time.sleep(0.05)
+        return None
+
+    @pytest.mark.xfail(
+        reason="Known bug, autokey/autokey#1007: the modifier's KeyRelease "
+               "is swallowed by AutoKey's X11 grab instead of being "
+               "forwarded to the focused window. strict=True so this turns "
+               "into a hard failure (XPASS) the moment a real fix lands, as "
+               "a prompt to remove this marker.",
+        strict=True,
+    )
+    def test_modifier_release_reaches_focused_window_after_hotkey_use(self):
+        """
+        Press <ctrl>, press '1' (triggering the grabbed hotkey), release
+        <ctrl> *before* releasing '1'. The focused window should still see
+        the <ctrl> KeyRelease.
+        """
+        hotkey = Mock()
+        hotkey.hotKey = '1'
+        hotkey.modifiers = [Key.CONTROL]
+        hotkey.get_applicable_regex.return_value = None
+
+        self.ifc.grab_hotkey(hotkey)
+        self.ifc.queue.join()
+
+        ctrl_keycode = self.ifc._XInterfaceBase__lookupKeyCode(Key.CONTROL)
+        one_keycode = self.ifc._XInterfaceBase__lookupKeyCode('1')
+
+        disp = self.ifc.localDisplay
+        xtest.fake_input(disp, X.KeyPress, ctrl_keycode)
+        disp.sync()
+        xtest.fake_input(disp, X.KeyPress, one_keycode)
+        disp.sync()
+        xtest.fake_input(disp, X.KeyRelease, ctrl_keycode)
+        disp.sync()
+        xtest.fake_input(disp, X.KeyRelease, one_keycode)
+        disp.sync()
+
+        evt = self._wait_for_event(self.target_display, X.KeyRelease, ctrl_keycode)
+        assert evt is not None, (
+            "Focused window never received the <ctrl> KeyRelease event; "
+            "the modifier is left stuck from that application's point of "
+            "view (autokey/autokey#1007)."
+        )


### PR DESCRIPTION
## Summary
Adds a regression test that reproduces #1007 (a hotkey modifier like `<ctrl>` gets left "stuck" from the focused application's point of view if it's released before the non-modifier key it's combined with).

**This is a reproduction harness, not a fix.** The test is intentionally marked `xfail(strict=True)`: it documents the known bug without failing CI, and will turn into a hard failure (XPASS) the moment a real fix lands, as a forcing function to remove the marker at that point.

## Why a test-first approach
#1009 previously proposed a fix for this issue directly, but stalled: it targeted `master` instead of `develop`, needed a rebase that never happened, and left an open question about whether its `send_event`/`flush` calls needed to run on AutoKey's dedicated Xlib thread rather than the event-handler thread (Xlib isn't thread-safe). See the discussion on #1009 for the full history.

Rather than resurrect that PR, this adds a harness that reliably reproduces the bug in CI first, so any future fix (including a reworked version of #1009's approach) has something concrete to turn green against, and so a regression can't silently reappear later.

## What it does
`TestModifierKeyReleaseForwarding` in `tests/test_interface.py`:
- Exercises AutoKey's *real* `grab_key`/`__flush_events` machinery against a live Xvfb X server — not a mocked interface layer.
- Uses a second Xlib connection as a stand-in for "the focused application."
- Grabs `<ctrl>+1` the way a real hotkey would be, then injects the exact failure-triggering sequence via `XTest`: `<ctrl>` down, `1` down, `<ctrl>` up, `1` up.
- Asserts the focused window's connection actually receives the `<ctrl>` `KeyRelease`. Today it doesn't.

I validated the harness in both directions before adding the `xfail` marker: it fails against current `develop`, and passes when an adapted version of #1009's forwarding logic is applied locally (then reverted — no production code changes are included here).

## Other changes
- Add `xvfb` to `apt-requirements.txt`, needed to reproduce this locally under `act`; real CI already gets it from the GitHub-hosted runner image.
- Populate `common.ARGS` in the test's setup: outside a real app bootstrap it's `None`, which silently no-ops every real `grab_key` call instead of raising, since `__eventLoop`'s catch-all swallows the `AttributeError`.
- Scope the `XInterfaceBase.queue` override (a class-level attribute shared by every instance in the process) with `patch.object` so it's restored on teardown instead of leaking a fresh queue forward into whichever test runs next in the session.

## Test plan
- [x] `pytest tests/test_interface.py -v` — passes, with the new test showing as `XFAIL` for the documented reason
- [x] Full suite run clean aside from pre-existing, unrelated issues (confirmed independent of this change via `git stash`)

Refs #1007, #1009