### PR TITLE
Fix intermittent RuntimeError caused by concurrent X11 display access (rebase + extend #1092)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -90,6 +90,7 @@ Bug fixes
 - Fix fake keyboard events not being emitted in a timely manner in some cases
 - Upgrade the **develop** branch to satisfy issue #773.
 - Fix selection when cloning a phrase or script
+- Fixed intermittent python-xlib RuntimeError caused by concurrent thread access to the X11 display.
 
 Other changes
 -------------

--- a/lib/autokey/interface.py
+++ b/lib/autokey/interface.py
@@ -119,19 +119,21 @@ class XWindowInterface(AbstractWindowInterface):
 
     def __init__(self):
         self.localDisplay = display.Display()
+        self.xlib_lock = threading.Lock()
         # Window name atoms
         self.__NameAtom = self.localDisplay.intern_atom("_NET_WM_NAME", True)
         self.__VisibleNameAtom = self.localDisplay.intern_atom("_NET_WM_VISIBLE_NAME", True)
 
     def get_window_info(self, window=None, traverse: bool=True) -> WindowInfo:
-        try:
-            if window is None:
-                window = self.localDisplay.get_input_focus().focus
-            return self._get_window_info(window, traverse)
-        except error.BadWindow:
-            logger.warning("Got BadWindow error while requesting window information.")
-            return self._create_window_info(window, "", "")
-            
+        with self.xlib_lock:
+            try:
+                if window is None:
+                    window = self.localDisplay.get_input_focus().focus
+                return self._get_window_info(window, traverse)
+            except error.BadWindow:
+                logger.warning("Got BadWindow error while requesting window information.")
+                return self._create_window_info(window, "", "")
+
     #  Add missing get_window_list() method required by AbstractWindowInterface
     #
     #  Not sure if this ever gets called but this is a best guess, based off
@@ -166,7 +168,7 @@ class XWindowInterface(AbstractWindowInterface):
             })
         logger.debug('autokey.interface.get_window_list(filter_desktop={}) returned {}'.format(filter_desktop, json.dumps(winjsonarr, indent=4)))
         return winjsonarr
-		
+
     def get_window_title(self, window=None, traverse=True) -> str:
         return self.get_window_info(window, traverse).wm_title
 
@@ -291,6 +293,7 @@ class XInterfaceBase(threading.Thread, AbstractMouseInterface):
 
         self.eventThread.start()
         self.listenerThread.start()
+        self.xlib_lock = threading.Lock()
 
     @queue_method(queue)
     def flush(self):
@@ -487,15 +490,17 @@ class XInterfaceBase(threading.Thread, AbstractMouseInterface):
         :return: Tuple of the Mouse Location(x,y)
         :rtype: tuple
         """
-        pos = self.rootWindow.query_pointer()
-        return (pos.root_x, pos.root_y)
+        with self.xlib_lock:
+            pos = self.rootWindow.query_pointer()
+            return (pos.root_x, pos.root_y)
 
     def relative_mouse_location(self, window=None):
         #return relative mouse location within given window
-        if window==None:
-            window = self.localDisplay.get_input_focus().focus
-        pos = window.query_pointer()
-        return (pos.win_x, pos.win_y)
+        with self.xlib_lock:
+            if window==None:
+                window = self.localDisplay.get_input_focus().focus
+            pos = window.query_pointer()
+            return (pos.win_x, pos.win_y)
 
     def scroll_down(self, number):
         for i in range(0, number):

--- a/lib/autokey/interface.py
+++ b/lib/autokey/interface.py
@@ -272,6 +272,13 @@ class XInterfaceBase(threading.Thread, AbstractMouseInterface):
         self.lastChars = [] # QT4 Workaround
         self.__enableQT4Workaround = False # QT4 Workaround
         self.shutdown = False
+        # Guards every round-trip request/reply exchange on self.localDisplay.
+        # python-xlib's request/reply sequence-number bookkeeping is not
+        # thread-safe, and this connection is shared by eventThread
+        # (__eventLoop), listenerThread (__flush_events), and whichever
+        # thread calls public methods like mouse_location() directly (e.g.
+        # the scripting API). Must exist before either thread starts.
+        self.xlib_lock = threading.Lock()
 
         # Event loop
         self.eventThread = threading.Thread(target=self.__eventLoop)
@@ -293,7 +300,6 @@ class XInterfaceBase(threading.Thread, AbstractMouseInterface):
 
         self.eventThread.start()
         self.listenerThread.start()
-        self.xlib_lock = threading.Lock()
 
     @queue_method(queue)
     def flush(self):
@@ -588,7 +594,12 @@ class XInterfaceBase(threading.Thread, AbstractMouseInterface):
             elif method is not None and args is None:
                 logger.debug("__eventLoop: Got method {} with None arguments!".format(method))
             try:
-                method(*args)
+                # Every queued method eventually round-trips on
+                # self.localDisplay; serialize against listenerThread and
+                # any thread calling public methods (e.g. mouse_location())
+                # directly. See the note on self.xlib_lock in __init__.
+                with self.xlib_lock:
+                    method(*args)
             except Exception as e:
                 logger.exception("Error in X event loop thread: {}".format(e))
 
@@ -1038,21 +1049,26 @@ class XInterfaceBase(threading.Thread, AbstractMouseInterface):
         logger.debug("Left event loop.")
 
     def __flush_events(self):
+        # select() just waits on the raw socket fd; it doesn't touch
+        # python-xlib's request/reply bookkeeping, so it stays outside the
+        # lock (holding it here would block eventThread/scripting calls for
+        # up to the full 1s timeout on every idle iteration).
         readable, _, _ = select.select([self.localDisplay], [], [], 1)
         time.sleep(1)
         if self.localDisplay in readable:
             createdWindows = []
             destroyedWindows = []
 
-            for _ in range(self.localDisplay.pending_events()):
-                event = self.localDisplay.next_event()
-                if event.type == X.CreateNotify:
-                    createdWindows.append(event.window)
-                if event.type == X.DestroyNotify:
-                    destroyedWindows.append(event.window)
-                if event.type == X.MappingNotify:
-                    logger.debug("X Mapping Event Detected")
-                    self.on_keys_changed()
+            with self.xlib_lock:
+                for _ in range(self.localDisplay.pending_events()):
+                    event = self.localDisplay.next_event()
+                    if event.type == X.CreateNotify:
+                        createdWindows.append(event.window)
+                    if event.type == X.DestroyNotify:
+                        destroyedWindows.append(event.window)
+                    if event.type == X.MappingNotify:
+                        logger.debug("X Mapping Event Detected")
+                        self.on_keys_changed()
 
             for window in createdWindows:
                 if window not in destroyedWindows:


### PR DESCRIPTION
## Summary
Rebase of #1092 (Riccardo Sciabbarrasi / Riccardo-stack) onto `develop`, plus a fix for a gap I found in the locking while reviewing it. Credit for identifying the bug and the initial fix direction (a lock around the shared X11 connection) goes to Riccardo.

Original description:

> When AutoKey scripts call window.get_active_title() or mouse.get_location() concurrently with other X11 operations, python-xlib's internal request/reply tracking breaks, raising RuntimeError: 'Request reply to unknown request'.
>
> Fix by protecting synchronous Xlib calls in XInterfaceBase with a threading.Lock(), ensuring only one thread performs round-trip X11 requests at a time.

## The rebase
Only one real conflict: `develop` had independently added a `get_window_list()` method right where this PR's diff ends `get_window_info()`. Kept both — `develop`'s addition and this PR's `with self.xlib_lock:` wrapping. The rest (CHANGELOG.rst, the `mouse_location`/`relative_mouse_location`/`__init__` hunks) applied cleanly.

## The gap this PR closes
`josephj11` asked exactly the right question on the original thread: *"AutoKey is a threaded app. How does this affect other actions that may be triggered/running at the same time?"* Looking at `XInterfaceBase`, its `self.localDisplay` connection is touched by three separate actors, and the original fix only synchronizes one of them against itself:

1. **`listenerThread`** (`__flush_events`), running continuously for the app's whole lifetime — round-trips via `pending_events()`/`next_event()` roughly once a second. **Not locked.**
2. **`eventThread`**, dispatching every queued send/grab operation (`__grabHotkey`, `send_string`, keycode lookups, etc.) — all of which round-trip on the same connection. **Not locked.**
3. **Whichever thread calls the scripting API directly** (`mouse.get_location()`, `window.get_active_title()`). **This is the only one the original fix locks.**

python-xlib's request/reply sequence-number bookkeeping isn't thread-safe for a shared `Display`, so *any two* of these three interleaving a round-trip can produce the reported error — not just two scripting-API calls colliding with each other. Since `listenerThread` runs for the app's entire life, that's the most likely real-world collision, and it was left completely unguarded.

This commit (separate from the rebased original, for a clean diff to review):
- Moves `xlib_lock`'s creation before `eventThread`/`listenerThread` start (it was created after `.start()` in the original — harmless today since neither thread used it, but worth fixing while touching this).
- Locks `__eventLoop`'s dispatch point (`with self.xlib_lock: method(*args)`), covering every queued operation in one place rather than each individually.
- Locks `__flush_events`' `pending_events()`/`next_event()` read section — deliberately **not** the blocking `select()` call before it, since holding the lock there would stall `eventThread`/scripting callers for up to the full 1s poll timeout on every otherwise-idle cycle.

## Verification
- `tests/test_interface.py` suite still passes.
- App still starts cleanly end-to-end under Xvfb (`dbus-run-session -- python3 -m autokey.qtui -c`).
- Wrote a synthetic stress test: several threads hammering `mouse_location()`, a thread generating real window create/destroy X events, and two threads continuously churning `grab_hotkey`/`ungrab_hotkey` through `eventThread` — run for 40s against both the unpatched-and-original-fix-only baseline and this extended version. **I was not able to reproduce the original `RuntimeError` synthetically in this environment, even against the baseline.** I want to be upfront about that rather than claim empirical proof I don't have — the case for this change rests on the code-path analysis above (which actors touch the shared connection unsynchronized), not on a reproduced failure. No regressions or deadlocks observed in either version under the stress test.

Refs #1092