### PR TITLE
Add packaging and pyasyncore to pip-requirements.txt

### DIFF
--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -1,10 +1,12 @@
 dbus-python
 pyinotify
+pyasyncore; python_version>="3.12"
 python-xlib
 PyGObject
 PyQt5
 QScintilla
 pyhamcrest
 python-magic
+packaging
 pyudev
 evdev


### PR DESCRIPTION
## Summary
`pip-requirements.txt` is missing two packages that `setup.py`'s `install_requires` already declares, so a real `pip install .` gets them for free, but running straight from source with `pip install -r pip-requirements.txt` (a venv, for example) does not.

## What's broken without this
- `ModuleNotFoundError: No module named 'packaging'` from `lib/autokey/configmanager/version_upgrading.py`, which does `from packaging.version import parse as vparse`.
- `ModuleNotFoundError: No module named 'asyncore'` from `pyinotify`, which still does `import asyncore` directly. Python 3.12 removed `asyncore` from the standard library (PEP 594); `pyasyncore` reinstates it under that same module name, which is exactly what `setup.py` already pulls in via `pyasyncore; python_version>="3.12"`.

Found these by actually running the app from source in a plain venv (`pip install -r pip-requirements.txt`, then `python3 -m autokey.qtui -c` / `autokey.gtkui`) — both errors reproduce on current `develop`, unrelated to any other in-flight PR.

## Change
Adds `packaging` and `pyasyncore; python_version>="3.12"` to `pip-requirements.txt`, matching `setup.py`'s existing markers.