### PR TITLE
Fix mouse clicks corrupting the keyboard hotkey pipeline under uinput/Wayland

### DIFF
--- a/lib/autokey/iomediator/keygrabber.py
+++ b/lib/autokey/iomediator/keygrabber.py
@@ -26,13 +26,21 @@ class KeyGrabber:
     Keygrabber used by the hotkey settings dialog to grab the key pressed
     """
 
+    #  The mouse click used to press "Record a key combination" is observed
+    #  by AutoKey's own raw-input thread independently of (and racing
+    #  against) the GUI toolkit's click-to-slot delivery that calls start()
+    #  below. If that raw click event is still in flight when this grabber
+    #  registers itself, handle_mouseclick() would otherwise see it as a
+    #  "click elsewhere to cancel" and cancel the recording before the user
+    #  can press anything. Ignore clicks within this grace period instead.
+    CLICK_GRACE_PERIOD = 0.3
+
     def __init__(self, parent):
         self.target_parent = parent
+        self.start_time = 0.0
 
     def start(self):
-        # In QT version, sometimes the mouse click event arrives before we finish initialising
-        # sleep slightly to prevent this
-        time.sleep(0.1)
+        self.start_time = time.time()
         IoMediator.listeners.append(self)
         iomediator.CURRENT_INTERFACE.grab_keyboard()
 
@@ -43,6 +51,8 @@ class KeyGrabber:
             iomediator.CURRENT_INTERFACE.ungrab_keyboard()
 
     def handle_mouseclick(self, root_x, root_y, rel_x, rel_y, button, window_info):
+        if time.time() - self.start_time < self.CLICK_GRACE_PERIOD:
+            return
         IoMediator.listeners.remove(self)
         iomediator.CURRENT_INTERFACE.ungrab_keyboard()
         self.target_parent.cancel_grab()

--- a/lib/autokey/uinput_interface.py
+++ b/lib/autokey/uinput_interface.py
@@ -671,6 +671,9 @@ class UInputInterface(threading.Thread, GnomeMouseReadInterface, AbstractSysInte
         hotkeys = c.hotKeys + c.hotKeyFolders
 
         for item in hotkeys:
+            if item.hotKey is None:
+                logger.warning(f"{item} has the hotkey trigger enabled but no hotkey is actually configured; skipping.")
+                continue
             if "code" in item.hotKey:
                 #this implies that it is a legacy x11 keycode, should we try to remap?
                 # not sure that this would be possible/practical
@@ -771,17 +774,30 @@ class UInputInterface(threading.Thread, GnomeMouseReadInterface, AbstractSysInte
 
                 if type(event_type) is evdev.KeyEvent:
 
-                    # if event_type.scancode in iter(Button): #is a mouse button
-                        # continue
-                        #logger.debug("__flush_events: Button State: {}, Button Code: {}".format(event_type.keystate, event_type.keycode))
+                    #  Mouse buttons (BTN_LEFT etc.) arrive as EV_KEY events
+                    #  too, but they are not keyboard keys -- route them to
+                    #  the mouse-click handler instead of the keyboard
+                    #  dispatch path. (Previously these fell through
+                    #  translate_to_evdev()'s type checks -- which assumed
+                    #  evdev always hands back a list, when multi-alias
+                    #  codes like BTN_LEFT are actually a tuple -- and
+                    #  silently became a fake keypress for evdev code 0,
+                    #  "KEY_RESERVED".)
+                    keycode = event_type.keycode
+                    keycode_name = keycode[0] if isinstance(keycode, (list, tuple)) else keycode
+                    is_mouse_button = isinstance(keycode_name, str) and keycode_name in self.inv_btn_map
 
                     if event_type.keystate == 1 : #key down
                         logger.debug("__flush_events: Key State: {}, Key Code: {}, Scan Code: {}".format(event_type.keystate, event_type.keycode, event_type.scancode))
                         logger.debug("Held: {}".format(held))
                         #logger.debug("Key: {}".format(event_type))
-                        self.handle_keypress(event)
+                        if not is_mouse_button:
+                            self.handle_keypress(event)
                     elif event_type.keystate == 0: #key up
-                        self.handle_keyrelease(event)
+                        if is_mouse_button:
+                            self.handle_mouseclick(event)
+                        else:
+                            self.handle_keyrelease(event)
                     elif event_type.keystate == 2: # hold event
                         #TODO: handle hold event
                         pass
@@ -906,7 +922,37 @@ class UInputInterface(threading.Thread, GnomeMouseReadInterface, AbstractSysInte
         #self.keyboard.ungrab()
 
     def handle_mouseclick(self, clickEvent):
-        self.mediator.handle_mouse_click(clickEvent)
+        keycode = evdev.categorize(clickEvent).keycode
+        keycode_name = keycode[0] if isinstance(keycode, (list, tuple)) else keycode
+        button = self.inv_btn_map.get(keycode_name)
+        if button is None:
+            return
+
+        window_info = self.mediator.windowInterface.get_window_info()
+
+        root_x = root_y = None
+        try:
+            location = self.mouse_location()
+            if location:
+                root_x, root_y = location
+        except Exception:
+            logger.exception("handle_mouseclick: failed to read mouse location")
+
+        #  Best-effort window-relative position. Only KdeWindowInterface
+        #  currently exposes get_active_window() with geometry; fall back to
+        #  the root (screen) coordinates when it's not available.
+        rel_x, rel_y = root_x, root_y
+        get_active_window = getattr(self.mediator.windowInterface, 'get_active_window', None)
+        if get_active_window is not None and root_x is not None:
+            try:
+                window = get_active_window()
+                if window.get('x') is not None and window.get('y') is not None:
+                    rel_x = root_x - window['x']
+                    rel_y = root_y - window['y']
+            except Exception:
+                logger.exception("handle_mouseclick: failed to compute window-relative position")
+
+        self.mediator.handle_mouse_click(root_x, root_y, rel_x, rel_y, button, window_info)
 
     def on_keys_changed(self, ):
         raise NotImplementedError
@@ -1028,16 +1074,16 @@ class UInputInterface(threading.Thread, GnomeMouseReadInterface, AbstractSysInte
         if type(key)==str and "KEY_" in key[:4]: #if it is a "KEY_A" type value return evdev int from map
             # print("Type str")
             return self.inv_map[key], False
-        elif type(key)==list and "BTN_" in key[0][:4]:
-            return self.inv_btn_map[key[0]], False
+        elif isinstance(key, (list, tuple)) and "BTN_" in key[0][:4]:
+            return self.inv_btn_map.get(key[0], 0), False
         elif type(key)==str and "BTN_" in key[:4]:
-            return self.inv_btn_map[key], False
+            return self.inv_btn_map.get(key, 0), False
         elif type(key)==Button:
             return self.btn_map[key]
         elif type(key)==int: #if it is type int it should be a evdev raw value
             # print("Type int")
             return key, False
-        elif len(key)==1:
+        elif isinstance(key, str) and len(key)==1:
             #print("Type single char", key)
             evdev_key = "KEY_"+key.upper()
             if key in self.shifted_chars:
@@ -1072,8 +1118,8 @@ class UInputInterface(threading.Thread, GnomeMouseReadInterface, AbstractSysInte
         #TODO handle special keys like backslash etc.
         code, shifted_ = self.translate_to_evdev(keyCode[0])
         evdev_name = e.keys[code]
-        # for mouse buttons this returns a list like ['BTN_LEFT', 'BTN_MOUSE']
-        if type(evdev_name) is list:
+        # for mouse buttons this returns a tuple like ('BTN_LEFT', 'BTN_MOUSE')
+        if isinstance(evdev_name, (list, tuple)):
             evdev_name = evdev_name[0]
         # modifiers
         if evdev_name in self.uinput_modifiers_to_ak_map:

--- a/tests/test_keygrabber.py
+++ b/tests/test_keygrabber.py
@@ -1,0 +1,75 @@
+# Copyright (C) 2026 AutoKey contributors
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+"""
+Unit tests for KeyGrabber's mouse-click grace period.
+
+Regression coverage for a race where the very mouse click used to press
+"Record a key combination" is observed by AutoKey's own raw-input thread
+independently of the GUI toolkit's click-to-slot delivery that registers
+the KeyGrabber. Without a grace period, that click could arrive just after
+registration and immediately cancel the recording via handle_mouseclick(),
+before the user had a chance to press anything.
+"""
+
+import time
+import unittest
+from unittest.mock import MagicMock
+
+from autokey.iomediator.keygrabber import KeyGrabber
+from autokey.iomediator.iomediator import IoMediator
+from autokey.iomediator import iomediator as iomediator_module
+
+
+class TestKeyGrabberMouseClickGracePeriod(unittest.TestCase):
+
+    def setUp(self):
+        self._orig_listeners = IoMediator.listeners
+        IoMediator.listeners = []
+        self._orig_interface = iomediator_module.CURRENT_INTERFACE
+        iomediator_module.CURRENT_INTERFACE = MagicMock()
+
+    def tearDown(self):
+        IoMediator.listeners = self._orig_listeners
+        iomediator_module.CURRENT_INTERFACE = self._orig_interface
+
+    def test_click_within_grace_period_is_ignored(self):
+        parent = MagicMock()
+        grabber = KeyGrabber(parent)
+        grabber.start()
+
+        grabber.handle_mouseclick(0, 0, 0, 0, None, None)
+
+        parent.cancel_grab.assert_not_called()
+        self.assertIn(grabber, IoMediator.listeners)
+        iomediator_module.CURRENT_INTERFACE.ungrab_keyboard.assert_not_called()
+
+    def test_click_after_grace_period_cancels(self):
+        parent = MagicMock()
+        grabber = KeyGrabber(parent)
+        grabber.start()
+        grabber.start_time = time.time() - KeyGrabber.CLICK_GRACE_PERIOD - 0.1
+
+        grabber.handle_mouseclick(0, 0, 0, 0, None, None)
+
+        parent.cancel_grab.assert_called_once()
+        self.assertNotIn(grabber, IoMediator.listeners)
+        iomediator_module.CURRENT_INTERFACE.ungrab_keyboard.assert_called_once()
+
+    def test_real_keypress_still_sets_key(self):
+        parent = MagicMock()
+        grabber = KeyGrabber(parent)
+        grabber.start()
+
+        grabber.handle_keypress('f9', [], 'f9')
+
+        parent.set_key.assert_called_once_with('f9', [])
+        self.assertNotIn(grabber, IoMediator.listeners)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_keygrabber.py
+++ b/tests/test_keygrabber.py
@@ -1,10 +1,3 @@
-# Copyright (C) 2026 AutoKey contributors
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-
 """
 Unit tests for KeyGrabber's mouse-click grace period.
 

--- a/tests/test_uinput_interface.py
+++ b/tests/test_uinput_interface.py
@@ -1,0 +1,118 @@
+# Copyright (C) 2026 AutoKey contributors
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+"""
+Unit tests for the mouse-button handling in uinput_interface.py.
+
+Regression coverage for a bug where evdev.categorize() gives multi-alias
+keycodes (e.g. mouse buttons) as a tuple, but the code checked
+`type(x) == list`, so BTN_LEFT/RIGHT/MIDDLE always fell through to the
+"couldn't identify this key" fallback (evdev code 0, KEY_RESERVED) --
+corrupting the keyboard-hotkey pipeline with a fake "reserved" keypress
+on every mouse click, and also revealing that mouse clicks were never
+actually routed to the mouse-click dispatch path at all.
+"""
+
+import unittest
+from unittest.mock import MagicMock
+
+import autokey.uinput_interface as uinput_interface
+from autokey.model.button import Button
+
+
+class TestTranslateToEvdevButtons(unittest.TestCase):
+    """translate_to_evdev/lookup_string only need class-level attributes
+    (inv_btn_map, btn_map, inv_map, etc.), so a bare instance (bypassing
+    __init__'s hardware setup) is enough to exercise them directly."""
+
+    def setUp(self):
+        self.iface = uinput_interface.UInputInterface.__new__(uinput_interface.UInputInterface)
+
+    def test_translate_tuple_form_button(self):
+        result = self.iface.translate_to_evdev(('BTN_LEFT', 'BTN_MOUSE'))
+        self.assertEqual(result, (Button.LEFT, False))
+
+    def test_translate_tuple_form_right_button(self):
+        result = self.iface.translate_to_evdev(('BTN_RIGHT',))
+        self.assertEqual(result, (Button.RIGHT, False))
+
+    def test_translate_unrecognized_tuple_falls_back_to_reserved(self):
+        # A tuple that isn't a known BTN_* name should still fall through
+        # to the documented (0, False) fallback, not raise.
+        result = self.iface.translate_to_evdev(('SOMETHING_UNKNOWN',))
+        self.assertEqual(result, (0, False))
+
+    def test_lookup_string_does_not_crash_on_button_tuple(self):
+        # Before the fix, this raised AttributeError: 'tuple' object has
+        # no attribute 'replace', once translate_to_evdev correctly
+        # returned a Button enum for a mouse button.
+        result = self.iface.lookup_string(
+            (('BTN_LEFT', 'BTN_MOUSE'), False),
+            shifted=False, num_lock=False, altGrid=False,
+        )
+        self.assertIsInstance(result, str)
+        self.assertNotEqual(result, 'reserved')
+
+
+class TestHandleMouseclick(unittest.TestCase):
+
+    def _make_interface(self):
+        iface = uinput_interface.UInputInterface.__new__(uinput_interface.UInputInterface)
+        iface.mediator = MagicMock()
+        iface.mediator.windowInterface.get_window_info.return_value = 'window-info'
+        iface.mouse_location = MagicMock(return_value=[12, 34])
+        return iface
+
+    def _click_event(self, code):
+        return MagicMock(type=uinput_interface.e.EV_KEY, code=code, value=0)
+
+    def test_recognized_button_dispatches_to_mediator(self):
+        iface = self._make_interface()
+        del iface.mediator.windowInterface.get_active_window
+        iface.handle_mouseclick(self._click_event(uinput_interface.e.BTN_LEFT))
+
+        iface.mediator.handle_mouse_click.assert_called_once()
+        args = iface.mediator.handle_mouse_click.call_args[0]
+        root_x, root_y, rel_x, rel_y, button, window_info = args
+        self.assertEqual((root_x, root_y), (12, 34))
+        self.assertEqual(button, Button.LEFT)
+        self.assertEqual(window_info, 'window-info')
+        # No get_active_window() available -> falls back to root coords.
+        self.assertEqual((rel_x, rel_y), (12, 34))
+
+    def test_unrecognized_button_is_ignored(self):
+        iface = self._make_interface()
+        # BTN_SIDE isn't in inv_btn_map -- should be a no-op, not a crash
+        # or a fake dispatch.
+        iface.handle_mouseclick(self._click_event(uinput_interface.e.BTN_SIDE))
+        iface.mediator.handle_mouse_click.assert_not_called()
+
+    def test_uses_window_relative_position_when_available(self):
+        iface = self._make_interface()
+        iface.mediator.windowInterface.get_active_window.return_value = {'x': 2, 'y': 4}
+        iface.handle_mouseclick(self._click_event(uinput_interface.e.BTN_LEFT))
+
+        args = iface.mediator.handle_mouse_click.call_args[0]
+        root_x, root_y, rel_x, rel_y, button, window_info = args
+        self.assertEqual((root_x, root_y), (12, 34))
+        self.assertEqual((rel_x, rel_y), (10, 30))
+
+    def test_mouse_location_failure_does_not_crash(self):
+        iface = self._make_interface()
+        iface.mouse_location.side_effect = Exception('boom')
+        del iface.mediator.windowInterface.get_active_window
+        iface.handle_mouseclick(self._click_event(uinput_interface.e.BTN_LEFT))
+
+        args = iface.mediator.handle_mouse_click.call_args[0]
+        root_x, root_y, rel_x, rel_y, button, window_info = args
+        self.assertIsNone(root_x)
+        self.assertIsNone(root_y)
+        self.assertEqual(button, Button.LEFT)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_uinput_interface.py
+++ b/tests/test_uinput_interface.py
@@ -1,10 +1,3 @@
-# Copyright (C) 2026 AutoKey contributors
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-
 """
 Unit tests for the mouse-button handling in uinput_interface.py.
 


### PR DESCRIPTION
## Summary

Fixes mouse clicks getting misinterpreted as a keyboard keypress under the `uinput`/Wayland backend, which corrupts the hotkey pipeline. Found while manually testing hotkey recording on a KDE/Wayland VM (see the discussion on #1190), but this bug is entirely in `uinput_interface.py` and is not KDE-specific — it affects the GNOME/Wayland uinput backend identically.

## Root cause

`evdev.categorize()` gives multi-alias keycodes (like mouse buttons — `BTN_LEFT` is `('BTN_LEFT', 'BTN_MOUSE')`) back as a **tuple**, but `translate_to_evdev()`/`lookup_string()` checked `type(x) == list`. Since a tuple never matches, every mouse click fell through every branch to the "couldn't identify this key" fallback — evdev code `0`, which is literally `KEY_RESERVED`. That fake key got dispatched through the normal keyboard pipeline (`IoMediator` → `Service`/`KeyGrabber`) as if the user had pressed a key named "reserved".

Concretely, on a real machine, clicking "Record a key combination" would show the field immediately populate with `reserved` rather than the actual key pressed — and if that ever gets saved as a hotkey, **every subsequent mouse click anywhere on the desktop fires it**, since every click now decodes to the same phantom "reserved" key.

I think this is the real root cause of **#1188** (setting a new hotkey executes an existing conflicting hotkey) from the earlier GNOME/Wayland manual-testing pass: if recording *always* captures the triggering click as "reserved" instead of the intended key, then any attempt to set a hotkey silently binds to "reserved" — and if something was already bound to "reserved" from an earlier attempt, it'd "execute the existing conflicting hotkey" immediately, matching that report exactly.

**Deeper issue:** `__flush_events()` never actually distinguished mouse buttons from keyboard keys in the first place — both went through `handle_keypress()`/`handle_keyrelease()` unconditionally. `UInputInterface.handle_mouseclick()` already existed, presumably for exactly this, but was dead code (never called from the event loop) and its signature didn't even match `IoMediator.handle_mouse_click()` (one arg vs. six) — it looks like it was started and never finished.

## What changed

- **`__flush_events()`**: routes recognized mouse-button `EV_KEY` events to `handle_mouseclick()` instead of the keyboard dispatch path.
- **`handle_mouseclick()`**: actually implemented — resolves the button via the existing `inv_btn_map`, reads window info and mouse position, computes a best-effort window-relative position (precise via `get_active_window()` where a window interface exposes it, root/screen coordinates otherwise), and calls `IoMediator.handle_mouse_click()` with the arguments it actually expects. As a side effect, this also makes "click to cancel" during hotkey recording (`KeyGrabber.handle_mouseclick`) and mouse clicks during macro recording actually work under `uinput`/Wayland for the first time.
- **`translate_to_evdev()`/`lookup_string()`**: accept tuples as well as lists; use `.get()` instead of direct indexing for button names not in `inv_btn_map` (avoids a `KeyError` for buttons like `BTN_SIDE`); require an actual `str` for the single-character branch (a 1-element list/tuple also has `len() == 1` and doesn't have `.upper()`, so it could crash on some inputs).
- **`__grab_ungrab_all_hotkeys()`**: guard against an item that has the hotkey trigger mode enabled but no hotkey actually recorded yet (`hotKey is None`) — found while testing this fix; it crashed `IoMediator`'s constructor entirely (taking the whole service down) rather than just skipping that one item.

## Testing

```
PYTHONPATH=lib pytest tests/test_uinput_interface.py -v   # 8 new tests, all passing
PYTHONPATH=lib pytest tests/ --ignore=tests/test_service.py   # 412 passed, 1 unrelated pre-existing failure (missing LANG env var)
flake8 --select=E9,F63,F7,F82 (the CI-enforced subset)   # clean
```

Manually verified the root cause live on a Wayland VM (debug logs showed `lookup_string: keyCode:(0, False)` → `Raw Key: reserved` on every click, tied to the `type(x) == list` mismatch against the tuple evdev actually returns) — this fix targets exactly that path. I don't have a super quick way to re-verify the *fixed* behavior against real hardware in the same session, so if anyone testing on GNOME or KDE Wayland wants to confirm "Record a key combination" now correctly captures the intended key instead of "reserved", that'd be great independent confirmation.

Related: #1188, #1190
