### PR TITLE
feat(iomediator): auto-detect Wayland session and fallback to AtSpiInterface (#87)

### DIFF
--- a/lib/autokey/common.py
+++ b/lib/autokey/common.py
@@ -52,3 +52,4 @@ ICON_FILE_NOTIFICATION_DARK = "autokey-status-dark"
 ICON_FILE_NOTIFICATION_ERROR = "autokey-status-error"
 
 USING_QT = False
+IS_WAYLAND = bool(os.environ.get('WAYLAND_DISPLAY') or os.environ.get('XDG_SESSION_TYPE') == 'wayland')

--- a/lib/autokey/iomediator/iomediator.py
+++ b/lib/autokey/iomediator/iomediator.py
@@ -63,7 +63,10 @@ class IoMediator(threading.Thread):
             Key.NUMLOCK: False
         }
         
-        if self.interfaceType == X_RECORD_INTERFACE:
+        if common.IS_WAYLAND and self.interfaceType == X_RECORD_INTERFACE:
+            logger.warning("Wayland session detected: X11 record interface cannot capture global keys, falling back to AT-SPI interface")
+            self.interface = AtSpiInterface(self, service.app)
+        elif self.interfaceType == X_RECORD_INTERFACE:
             self.interface = XRecordInterface(self, service.app)
         else:
             self.interface = AtSpiInterface(self, service.app)


### PR DESCRIPTION
## Description
Fixes #87

### Summary of Changes:
- Added \IS_WAYLAND\ environment session check in \lib/autokey/common.py\ using \WAYLAND_DISPLAY\ and \XDG_SESSION_TYPE\.
- Automatically falls back to \AtSpiInterface\ when running on a Wayland compositor session to prevent X11 display recording crashes.
- Logs a clear warning alerting the user that AT-SPI interface is active for Wayland compatibility.

/claim #87