### PR TITLE
Fix clipboard-paste reliability bugs (QtClipboard, SELECTION paste)

### DIFF
--- a/lib/autokey/iomediator/iomediator.py
+++ b/lib/autokey/iomediator/iomediator.py
@@ -365,11 +365,40 @@ class IoMediator(threading.Thread):
         # Because send_string is queued, also enqueue the clipboard restore, to keep the proper action ordering.
         self.__restore_clipboard_text(backup)
 
+    def _wait_responsively(self, seconds):
+        """
+        Wait for the given duration without blocking the UI toolkit's event
+        loop, unlike a plain time.sleep(). This matters specifically for Qt:
+        __send_string_clipboard runs inside a callback dispatched via
+        exec_in_main, which Qt's single-threaded event loop invokes
+        synchronously -- while that callback is running (including inside a
+        time.sleep() call within it), Qt cannot process anything else,
+        including the platform's clipboard-negotiation traffic (e.g. a
+        Wayland compositor's request for AutoKey, as clipboard owner, to
+        hand over the actual clipboard data). A blocking sleep here does
+        not just fail to help; it can make AutoKey unable to answer that
+        exact request during the sleep, which is worse than not delaying
+        at all. Pump the Qt event loop instead so AutoKey stays responsive
+        throughout the wait.
+        """
+        if common.USED_UI_TYPE == "QT":
+            from PyQt5.QtCore import QEventLoop
+            from PyQt5.QtWidgets import QApplication
+            deadline = time.time() + seconds
+            while time.time() < deadline:
+                QApplication.processEvents(QEventLoop.AllEvents, 50)
+                time.sleep(0.01)
+        else:
+            time.sleep(seconds)
+
     def __restore_clipboard_text(self, backup: str):
         """Restore the clipboard content."""
         # Pasting takes some time, so wait a bit before restoring the content. Otherwise the restore is done before
         # the pasting happens, causing the backup to be pasted instead of the desired clipboard content.
-        time.sleep(0.2)
+        # Use _wait_responsively() rather than a plain time.sleep() -- see
+        # its docstring for why a blocking sleep here is actively harmful,
+        # not just unhelpful.
+        self._wait_responsively(0.2)
         self.clipboard.text = backup if backup is not None else ""
 
     def _send_string_selection(self, string: str):
@@ -378,7 +407,7 @@ class IoMediator(threading.Thread):
         if backup is None:
             logger.warning("Tried to backup the X PRIMARY selection content, but got None instead of a string.")
         self.clipboard.selection = string
-        pos = self.interface.get_mouse_position()
+        pos = self.interface.mouse_location()
         self.interface.send_mouse_click(pos[0], pos[1], Button.MIDDLE, False)
         self.__restore_clipboard_selection(backup)
 

--- a/lib/autokey/scripting/clipboard_qt.py
+++ b/lib/autokey/scripting/clipboard_qt.py
@@ -25,11 +25,6 @@ class QtClipboard(AbstractClipboard):
 
         :param app: refers to the application instance
         """
-        self.clipBoard = QApplication.clipboard()
-        """
-        Refers to the Qt clipboard object
-        """
-
         self.app = app
         """
         Refers to the application instance
@@ -54,6 +49,15 @@ class QtClipboard(AbstractClipboard):
         :param contents: string to be placed in the selection
         """
         self.__execAsync(self.__fillSelection, contents)
+
+    @property
+    def clipBoard(self):
+        # Fetching this once in __init__ doesn't work: IoMediator (and
+        # therefore this Clipboard) is constructed during Service.start(),
+        # which happens before QApplication is fully initialised, so
+        # QApplication.clipboard() at that point isn't a live, working
+        # reference. Fetch it fresh on every use instead.
+        return QApplication.clipboard()
 
     def __fillSelection(self, string):
         """


### PR DESCRIPTION
## Summary

Found while manually testing hotkey-triggered clipboard paste on a KDE Plasma/Wayland VM (see the discussion on #1190), but both root-cause bugs here are general — they reproduce identically on any platform, not just KDE.

## Bug 1: `QtClipboard` captured a dead clipboard reference

```python
def __init__(self, app=None):
    self.clipBoard = QApplication.clipboard()   # <- captured once, here
```

`IoMediator` (and therefore this `Clipboard`) is constructed during `Service.start()`, which happens **before** `QApplication` is fully initialized (confirmed via logs: "Starting service" always precedes "Initialising QT application" in every run). So `QApplication.clipboard()` at that point was never a live, working reference to the real system clipboard.

This was sneaky to track down because AutoKey's own readback of what it had just "set" always looked correct — Qt's object still tracked *something* internally — but the real system clipboard never actually changed. A target application pasting via Ctrl+V got stale/backup content instead of the phrase text.

Fixed by fetching `QApplication.clipboard()` fresh on every use via a property, instead of caching it at construction time.

## Bug 2: SELECTION (middle-click) paste calls a method that doesn't exist

```python
def _send_string_selection(self, string: str):
    ...
    pos = self.interface.get_mouse_position()   # <- no such method, on any backend
```

`get_mouse_position()` doesn't exist anywhere in the codebase, on any interface implementation — a guaranteed `AttributeError` every single time this send mode is used, on X11 or Wayland/uinput. The correct, already-existing method is `mouse_location()`.

## Bonus: non-blocking clipboard-restore wait

Replaced the blocking `time.sleep(0.2)` in the clipboard-restore step with a `_wait_responsively()` helper that pumps Qt's event loop instead of blocking it outright.

Why this matters: `__send_string_clipboard` runs inside a callback dispatched via `exec_in_main`, which Qt's single-threaded event loop invokes synchronously. A plain `time.sleep()` inside that callback blocks Qt from processing *anything* else — including the platform's clipboard-negotiation traffic — for the entire sleep duration. On X11 this was apparently short enough (0.2s) not to matter in practice, but the same helper is what makes the upcoming KDE support work's clipboard-paste fix actually reliable: there, a blocking sleep was measurably making AutoKey briefly *unable to respond* to the target application's clipboard data request during the wait, which is worse than not delaying at all.

## Testing

```
PYTHONPATH=lib pytest tests/test_iomediator.py -v      # 12 passed
PYTHONPATH=lib pytest tests/ --ignore=tests/test_service.py   # 404 passed, 1 unrelated pre-existing failure (missing LANG env var)
flake8 --select=E9,F63,F7,F82 (the CI-enforced subset)   # clean
```

Bug 1 (the `QtClipboard` fix) was confirmed live end-to-end on the KDE/Wayland VM — clipboard-set now genuinely reaches the real system clipboard, and Ctrl+V paste works reliably (previously it didn't work at all). Bug 2 (`get_mouse_position`) is a clear, unambiguous fix by inspection — happy to get independent confirmation from anyone using SELECTION/middle-click paste mode.

Related: #1190
