### PR TITLE
Fix misplaced CHANGELOG.rst entry for PR #1168

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -90,6 +90,7 @@ Bug fixes
 - Fix fake keyboard events not being emitted in a timely manner in some cases
 - Upgrade the **develop** branch to satisfy issue #773.
 - Fix selection when cloning a phrase or script
+- Remove leftover debug ``print()`` calls from ``UnityLauncher.rebuild_menu`` in the GTK notifier that spammed the terminal on every menu rebuild.
 
 Other changes
 -------------
@@ -700,8 +701,3 @@ Modified the launcher and other files to allow for editable installs ("pip insta
 Added an "about" dialog for the Python 3 port.
 
 Changed hyperlink for bug reports.
-
-PR #1168 Changes
-----------------
-
-- Remove leftover debug `print()` calls from `UnityLauncher.rebuild_menu` in the GTK notifier that spammed the terminal on every menu rebuild.


### PR DESCRIPTION
PR #1168's CHANGELOG.rst entry didn't end up where review requested. It
was left as a standalone "PR #1168 Changes" section appended to the very
bottom of the file, which puts it under "Version 0.91.0 <2014-02-14>" —
the oldest release in the changelog — rather than the current "Version
Develop" section.

This is a pure documentation fix: moves the one-line entry into the
existing top-of-file "Bug fixes" section and removes the stray section
at the bottom. No code changes.

The verification/process question raised during PR #1168's review is
being handled separately from this fix.
