### PR TITLE
Add a manual verification checklist for behavior-changing PRs

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -26,6 +26,11 @@ automatically be built.
 
 If you make any scripting API changes please be sure to run `python3 extractDoc.py` to regenerate the autocompletion text files used by both Qt and GTK. (and add the changes to your commit!)
 
+See MANUAL_TESTING.rst for the manual verification checklist required for
+PRs that change AutoKey's runtime behavior. Additional test scenarios are
+welcome -- please contribute a PR to MANUAL_TESTING.rst if you know of a
+case it should cover.
+
 Testing
 =======
 Running the tests is simple: Checkout `develop` (or v>0.96.0) and run `tox`

--- a/MANUAL_TESTING.rst
+++ b/MANUAL_TESTING.rst
@@ -1,0 +1,58 @@
+Manual Verification
+====================
+
+Automated tests (see `Testing`_ in CONTRIBUTORS.rst) mock out the display
+server, input devices, and desktop-specific IPC (D-Bus/KWin scripting), so
+they can't catch bugs that only show up when AutoKey is actually driving a
+real X11/Wayland session. This checklist is for verifying PRs that change
+AutoKey's runtime behavior (input handling, clipboard, window detection,
+UI notifiers), per the verification policy in CONTRIBUTORS.rst.
+
+When to use this
+-----------------
+Run this checklist when a PR touches: keyboard/mouse input handling,
+clipboard operations, window detection or manipulation, hotkey/abbreviation
+triggering, or desktop-integration code (notifiers, tray icons, KWin/GNOME
+extensions). Purely cosmetic changes don't need it.
+
+How to compare
+---------------
+Where practical, check out ``master``, ``develop``, and the PR branch as
+three separate installs (a plain ``pip install -e .`` in a venv is often
+*not* enough -- some issues (e.g. desktop-launcher hooks) only appear in a
+full package install). Reproduce the reported behavior on the base branch
+first, then confirm the PR branch fixes or doesn't regress it.
+
+Environments
+-------------
+Test on whichever of these the PR's changes actually touch:
+
+- **X11** (any traditional X11 desktop)
+- **GNOME / Wayland**
+- **KDE Plasma / Wayland**
+
+Core checklist
+---------------
+For each applicable environment:
+
+1. **Phrase expansion via abbreviation** -- type a configured abbreviation, confirm it expands.
+2. **Phrase/script trigger via global hotkey** -- confirm the hotkey fires the correct phrase/script.
+3. **Paste method: keyboard** -- send a phrase via simulated keystrokes; confirm correct text in the target app.
+4. **Paste method: clipboard (Ctrl+V)** -- confirm the phrase actually lands on the system clipboard and pastes; confirm the original clipboard contents are restored afterward.
+5. **Paste method: mouse selection (middle-click)** -- confirm the phrase is pasted via PRIMARY selection.
+6. **Record a key combination -- keyboard-triggered** -- open the dialog via keyboard, confirm the recorded key is correct.
+7. **Record a key combination -- mouse-triggered** -- open the dialog by clicking a button, confirm the click doesn't get misrecorded as the key.
+8. **Window detection (crosshair click-to-select)** -- confirm it correctly identifies both X11 and native-Wayland target windows, where applicable.
+9. **Enable/disable expansions toggle** -- via tray icon/notifier menu, confirm expansions actually stop/resume.
+10. **Config GUI sanity** -- open the relevant GTK or Qt config window, confirm no crash and settings persist.
+
+Add or adjust steps as needed for what the specific PR changes -- this
+list is a baseline, not exhaustive.
+
+Contributing new scenarios
+----------------------------
+This checklist is a starting point, not a complete list. If you find a
+bug that this checklist wouldn't have caught, or you know of an
+interaction path worth covering, please contribute a PR adding it here.
+
+.. _Testing: CONTRIBUTORS.rst#testing


### PR DESCRIPTION
Continuing the process work from #1195 and #1196: automated tests mock
out the display server, input devices, and desktop-specific IPC, so
they can't catch bugs that only show up when AutoKey is actually
driving a real X11/Wayland session.

Adds MANUAL_TESTING.rst, a baseline checklist covering the core
interaction paths (abbreviation expansion, hotkey triggers, each paste
method, key-combination recording via keyboard and mouse, window
detection, the enable/disable toggle, config GUI sanity) across X11,
GNOME/Wayland, and KDE Plasma/Wayland, along with the
compare-behavior-across-branches methodology referenced in #1196's
"Verification Before Merging" section.

This is meant to grow over time -- additional scenarios are welcome as
follow-up PRs, and the checklist says so.
