### PR TITLE
fix: import TriggerMode from correct module in engine and test_service

### DIFF
--- a/lib/autokey/scripting/engine.py
+++ b/lib/autokey/scripting/engine.py
@@ -24,6 +24,7 @@ from typing import Tuple, Optional, List, Union
 import autokey.model.folder
 import autokey.model.helpers
 import autokey.model.phrase
+import autokey.model.triggermode
 import autokey.model.script
 from autokey import configmanager
 from autokey.model.key import Key
@@ -299,7 +300,7 @@ Folders created within temporary folders must themselves be set temporary")
 
         self.monitor.suspend()
         p = autokey.model.phrase.Phrase(description, contents)
-        p.modes.append(autokey.model.helpers.TriggerMode.ABBREVIATION)
+        p.modes.append(autokey.model.triggermode.TriggerMode.ABBREVIATION)
         p.abbreviations = [abbr]
         folder.add_item(p)
         p.persist()
@@ -339,7 +340,7 @@ Folders created within temporary folders must themselves be set temporary")
 
         self.monitor.suspend()
         p = autokey.model.phrase.Phrase(description, contents)
-        p.modes.append(autokey.model.helpers.TriggerMode.HOTKEY)
+        p.modes.append(autokey.model.triggermode.TriggerMode.HOTKEY)
         p.set_hotkey(modifiers, key)
         folder.add_item(p)
         p.persist()

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -27,6 +27,7 @@ import tests.helpers_for_tests as testhelpers
 
 import autokey.model.folder
 import autokey.model.helpers
+import autokey.model.triggermode
 import autokey.model.script
 from autokey.configmanager import configmanager
 from autokey.configmanager.configmanager import ConfigManager
@@ -66,7 +67,7 @@ def test_start(tmp_path):
 def create_script(abbreviation, trigger_immediately=False, ignore_case=False):
     script = autokey.model.script.Script("script", "")
     script.add_abbreviation(abbreviation)
-    script.set_modes([autokey.model.helpers.TriggerMode.ABBREVIATION])
+    script.set_modes([autokey.model.triggermode.TriggerMode.ABBREVIATION])
     script.immediate = trigger_immediately
     script.ignoreCase = ignore_case
     script.parent = MagicMock()


### PR DESCRIPTION
## Description

Fixes #1199.

An earlier refactor moved `TriggerMode` into its own module (`autokey.model.triggermode`), but `lib/autokey/scripting/engine.py` and `tests/test_service.py` still referenced `autokey.model.helpers.TriggerMode`, causing an `AttributeError` on `engine.create_abbreviation()`, `engine.create_hotkey()`, and `test_set_triggered_abbreviation_uses_typed_abbreviation`.

This PR updates the imports and references to `autokey.model.triggermode.TriggerMode` in both files.

/claim #1199
