### PR TITLE
Fix AttributeError: TriggerMode is not in autokey.model.helpers

### DIFF
--- a/lib/autokey/scripting/engine.py
+++ b/lib/autokey/scripting/engine.py
@@ -22,11 +22,11 @@ from collections.abc import Iterable
 from typing import Tuple, Optional, List, Union
 
 import autokey.model.folder
-import autokey.model.helpers
 import autokey.model.phrase
 import autokey.model.script
 from autokey import configmanager
 from autokey.model.key import Key
+from autokey.model.triggermode import TriggerMode
 
 from autokey.scripting.system import System
 
@@ -299,7 +299,7 @@ Folders created within temporary folders must themselves be set temporary")
 
         self.monitor.suspend()
         p = autokey.model.phrase.Phrase(description, contents)
-        p.modes.append(autokey.model.helpers.TriggerMode.ABBREVIATION)
+        p.modes.append(TriggerMode.ABBREVIATION)
         p.abbreviations = [abbr]
         folder.add_item(p)
         p.persist()
@@ -339,7 +339,7 @@ Folders created within temporary folders must themselves be set temporary")
 
         self.monitor.suspend()
         p = autokey.model.phrase.Phrase(description, contents)
-        p.modes.append(autokey.model.helpers.TriggerMode.HOTKEY)
+        p.modes.append(TriggerMode.HOTKEY)
         p.set_hotkey(modifiers, key)
         folder.add_item(p)
         p.persist()

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -26,8 +26,8 @@ from tests.engine_helpers import *
 import tests.helpers_for_tests as testhelpers
 
 import autokey.model.folder
-import autokey.model.helpers
 import autokey.model.script
+from autokey.model.triggermode import TriggerMode
 from autokey.configmanager import configmanager
 from autokey.configmanager.configmanager import ConfigManager
 from autokey.service import Service
@@ -66,16 +66,13 @@ def test_start(tmp_path):
 def create_script(abbreviation, trigger_immediately=False, ignore_case=False):
     script = autokey.model.script.Script("script", "")
     script.add_abbreviation(abbreviation)
-    script.set_modes([autokey.model.helpers.TriggerMode.ABBREVIATION])
+    script.set_modes([TriggerMode.ABBREVIATION])
     script.immediate = trigger_immediately
     script.ignoreCase = ignore_case
     script.parent = MagicMock()
     return script
 
 
-@pytest.mark.xfail(reason="create_script() hits AttributeError: "
-                          "autokey.model.helpers has no attribute "
-                          "'TriggerMode' -- see #1199")
 @pytest.mark.parametrize("buffer, abbreviation, immediate, ignore_case, expected", [
     ("abbr ", "abbr", False, False, ("abbr", " ")),
     ("prefix abbr ", "abbr", False, False, ("abbr", " ")),


### PR DESCRIPTION
Fixes #1199.

engine.py's create_abbreviation() and create_hotkey() -- both public
scripting API methods -- and test_service.py's create_script() helper
referenced autokey.model.helpers.TriggerMode. That stopped existing
when an earlier refactor moved TriggerMode into its own module
(autokey.model.triggermode) without updating these two call sites.
Any script calling engine.create_abbreviation() or
engine.create_hotkey() would hit an AttributeError.

This was uncovered while getting #1182's CI pipeline running --
#1182 added a temporary xfail marker (referencing #1199) on the
affected test so its own pipeline could go green without masking the
bug. This PR fixes the actual bug and removes that marker.
