### PR TITLE
Fail fast on hung tests instead of exhausting CI's 6-hour job limit

### DIFF
--- a/lib/autokey/iomediator/iomediator.py
+++ b/lib/autokey/iomediator/iomediator.py
@@ -52,6 +52,12 @@ class IoMediator(threading.Thread):
     
     def __init__(self, service):
         threading.Thread.__init__(self, name="KeypressHandler-thread")
+        # If shutdown() ever can't deliver its sentinel to the queue (e.g.
+        # self.interface.cancel() blocks forever on a RECORD-extension race,
+        # see XRecordInterface.cancel()), a non-daemon thread here would
+        # block the whole process from exiting. XInterfaceBase already sets
+        # this; match it here as a safety net.
+        self.daemon = True
 
         self.queue = queue.Queue()
         self.listeners.append(service)

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,12 @@ addopts =
   # Summarize failed tests at the end, including xfails and skips:
   -r fa
   ; -v
+  # pytest-timeout is a declared dependency but was never actually given
+  # a timeout value, so a hung test (e.g. a real X11/DBus connection
+  # that never responds under Xvfb in CI) ran for 6 hours before GitHub's
+  # own job-execution ceiling killed it, twice. Fail fast instead.
+  --timeout=120
+  --timeout-method=thread
 
 
 [tox:tox]


### PR DESCRIPTION
Two `develop` push runs each had a `pytest` job hang for the full
6-hour GitHub Actions job-execution ceiling before being
force-cancelled — once during PR #1178's merge, once on the commit
right before it (a docs-only change, ruling out #1178's own diff as
the cause).

`pytest-timeout` is a declared test dependency but was never actually
given a timeout value anywhere, so nothing caught these hangs early.

Traced the actual hang with `py-spy`: `XRecordInterface.cancel()`
calls `self.join()` waiting for the X RECORD-extension listener
thread, which occasionally never returns — a race between
`record_enable_context()` and `record_disable_context()` that appears
specific to running under Xvfb in CI. Filed separately as #1202, since
fixing that race properly is a bigger, riskier change than this PR's
scope. Because the hanging call is inside `IoMediator.shutdown()`,
before it ever reaches the line that signals `IoMediator`'s own worker
thread to stop, that thread — also never marked daemon — is left
blocked forever too, which blocks the whole process from exiting even
after a test-level timeout fires.

This PR:
- Adds `--timeout=120` so a hung test fails fast instead of consuming
  CI hardware for hours.
- Adds `--timeout-method=thread` specifically because the default
  signal-based interrupt could itself get stuck retrying the blocking
  call — confirmed empirically by reproducing the race across 40 local
  test-suite runs under Xvfb: signal-based recovery succeeded 5/7
  times the race was hit, thread-based succeeded 7/7.
- Marks `IoMediator`'s thread `daemon`, matching `XInterfaceBase`, so
  a leaked thread from this race (or any other cause) can never block
  process exit again.

This doesn't fix the underlying race itself (#1202) — it makes it
fail loudly in ~2 minutes with an exact stack trace instead of
silently for 6 hours with none.
